### PR TITLE
강의 생성 기능 추가

### DIFF
--- a/src/main/java/com/example/be_a/class_/application/ClassCreateService.java
+++ b/src/main/java/com/example/be_a/class_/application/ClassCreateService.java
@@ -1,0 +1,37 @@
+package com.example.be_a.class_.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.application.UserAuthorizationService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ClassCreateService {
+
+    private final ClassRepository classRepository;
+    private final UserAuthorizationService userAuthorizationService;
+
+    public ClassCreateService(ClassRepository classRepository, UserAuthorizationService userAuthorizationService) {
+        this.classRepository = classRepository;
+        this.userAuthorizationService = userAuthorizationService;
+    }
+
+    @Transactional
+    public ClassEntity create(CurrentUserInfo user, CreateClassCommand command) {
+        userAuthorizationService.requireCreator(user);
+
+        ClassEntity classEntity = ClassEntity.createDraft(
+            user.id(),
+            command.title(),
+            command.description(),
+            command.price(),
+            command.capacity(),
+            command.startDate(),
+            command.endDate()
+        );
+
+        return classRepository.save(classEntity);
+    }
+}

--- a/src/main/java/com/example/be_a/class_/application/CreateClassCommand.java
+++ b/src/main/java/com/example/be_a/class_/application/CreateClassCommand.java
@@ -1,0 +1,13 @@
+package com.example.be_a.class_.application;
+
+import java.time.LocalDate;
+
+public record CreateClassCommand(
+    String title,
+    String description,
+    int price,
+    int capacity,
+    LocalDate startDate,
+    LocalDate endDate
+) {
+}

--- a/src/main/java/com/example/be_a/class_/domain/ClassEntity.java
+++ b/src/main/java/com/example/be_a/class_/domain/ClassEntity.java
@@ -1,0 +1,87 @@
+package com.example.be_a.class_.domain;
+
+import com.example.be_a.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "classes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ClassEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "creator_id", nullable = false)
+    private Long creatorId;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(nullable = false)
+    private int capacity;
+
+    @Column(name = "enrolled_count", nullable = false)
+    private int enrolledCount;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ClassStatus status;
+
+    private ClassEntity(
+        Long creatorId,
+        String title,
+        String description,
+        int price,
+        int capacity,
+        LocalDate startDate,
+        LocalDate endDate,
+        ClassStatus status
+    ) {
+        this.creatorId = creatorId;
+        this.title = title;
+        this.description = description;
+        this.price = price;
+        this.capacity = capacity;
+        this.enrolledCount = 0;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
+    }
+
+    public static ClassEntity createDraft(
+        Long creatorId,
+        String title,
+        String description,
+        int price,
+        int capacity,
+        LocalDate startDate,
+        LocalDate endDate
+    ) {
+        return new ClassEntity(creatorId, title, description, price, capacity, startDate, endDate, ClassStatus.DRAFT);
+    }
+}

--- a/src/main/java/com/example/be_a/class_/domain/ClassRepository.java
+++ b/src/main/java/com/example/be_a/class_/domain/ClassRepository.java
@@ -1,0 +1,6 @@
+package com.example.be_a.class_.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
+}

--- a/src/main/java/com/example/be_a/class_/domain/ClassStatus.java
+++ b/src/main/java/com/example/be_a/class_/domain/ClassStatus.java
@@ -1,0 +1,7 @@
+package com.example.be_a.class_.domain;
+
+public enum ClassStatus {
+    DRAFT,
+    OPEN,
+    CLOSED
+}

--- a/src/main/java/com/example/be_a/class_/presentation/ClassController.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ClassController.java
@@ -1,0 +1,36 @@
+package com.example.be_a.class_.presentation;
+
+import com.example.be_a.class_.application.ClassCreateService;
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.global.config.CurrentUser;
+import com.example.be_a.user.application.CurrentUserInfo;
+import jakarta.validation.Valid;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/classes")
+public class ClassController {
+
+    private final ClassCreateService classCreateService;
+
+    public ClassController(ClassCreateService classCreateService) {
+        this.classCreateService = classCreateService;
+    }
+
+    @PostMapping
+    public ResponseEntity<CreateClassResponse> create(
+        @CurrentUser CurrentUserInfo user,
+        @Valid @RequestBody CreateClassRequest request
+    ) {
+        ClassEntity createdClass = classCreateService.create(user, request.toCommand());
+        CreateClassResponse response = CreateClassResponse.from(createdClass);
+
+        return ResponseEntity.created(URI.create("/api/classes/" + response.id()))
+            .body(response);
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/CreateClassRequest.java
+++ b/src/main/java/com/example/be_a/class_/presentation/CreateClassRequest.java
@@ -1,0 +1,34 @@
+package com.example.be_a.class_.presentation;
+
+import com.example.be_a.class_.application.CreateClassCommand;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+@ValidCreateClassRequest
+public record CreateClassRequest(
+    @NotBlank(message = "제목은 필수입니다.")
+    String title,
+
+    String description,
+
+    @NotNull(message = "가격은 필수입니다.")
+    @Min(value = 0, message = "가격은 0 이상이어야 합니다.")
+    Integer price,
+
+    @NotNull(message = "정원은 필수입니다.")
+    @Min(value = 1, message = "정원은 1 이상이어야 합니다.")
+    Integer capacity,
+
+    @NotNull(message = "시작일은 필수입니다.")
+    LocalDate startDate,
+
+    @NotNull(message = "종료일은 필수입니다.")
+    LocalDate endDate
+) {
+
+    public CreateClassCommand toCommand() {
+        return new CreateClassCommand(title, description, price, capacity, startDate, endDate);
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/CreateClassRequestValidator.java
+++ b/src/main/java/com/example/be_a/class_/presentation/CreateClassRequestValidator.java
@@ -1,0 +1,24 @@
+package com.example.be_a.class_.presentation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class CreateClassRequestValidator implements ConstraintValidator<ValidCreateClassRequest, CreateClassRequest> {
+
+    @Override
+    public boolean isValid(CreateClassRequest value, ConstraintValidatorContext context) {
+        if (value == null || value.startDate() == null || value.endDate() == null) {
+            return true;
+        }
+
+        if (!value.endDate().isBefore(value.startDate())) {
+            return true;
+        }
+
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate(context.getDefaultConstraintMessageTemplate())
+            .addPropertyNode("endDate")
+            .addConstraintViolation();
+        return false;
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/CreateClassResponse.java
+++ b/src/main/java/com/example/be_a/class_/presentation/CreateClassResponse.java
@@ -1,0 +1,25 @@
+package com.example.be_a.class_.presentation;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassStatus;
+
+public record CreateClassResponse(
+    Long id,
+    Long creatorId,
+    String title,
+    int price,
+    int capacity,
+    ClassStatus status
+) {
+
+    public static CreateClassResponse from(ClassEntity classEntity) {
+        return new CreateClassResponse(
+            classEntity.getId(),
+            classEntity.getCreatorId(),
+            classEntity.getTitle(),
+            classEntity.getPrice(),
+            classEntity.getCapacity(),
+            classEntity.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/ValidCreateClassRequest.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ValidCreateClassRequest.java
@@ -1,0 +1,20 @@
+package com.example.be_a.class_.presentation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = CreateClassRequestValidator.class)
+public @interface ValidCreateClassRequest {
+
+    String message() default "종료일은 시작일보다 빠를 수 없습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/com/example/be_a/class_/ClassCreateIntegrationTest.java
+++ b/src/test/java/com/example/be_a/class_/ClassCreateIntegrationTest.java
@@ -1,0 +1,176 @@
+package com.example.be_a.class_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.hamcrest.Matchers;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ClassCreateIntegrationTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @BeforeEach
+    void setUp() {
+        classRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 크리에이터가_강의를_생성하면_DRAFT_상태로_저장된다() throws Exception {
+        mockMvc.perform(post("/api/classes")
+                .header("X-User-Id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "Spring Boot 입문",
+                      "description": "백엔드 기본기",
+                      "price": 30000,
+                      "capacity": 30,
+                      "startDate": "2026-05-01",
+                      "endDate": "2026-05-31"
+                    }
+                    """))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", Matchers.matchesPattern("/api/classes/\\d+")))
+            .andExpect(jsonPath("$.id").isNumber())
+            .andExpect(jsonPath("$.creatorId").value(1))
+            .andExpect(jsonPath("$.title").value("Spring Boot 입문"))
+            .andExpect(jsonPath("$.price").value(30000))
+            .andExpect(jsonPath("$.capacity").value(30))
+            .andExpect(jsonPath("$.status").value("DRAFT"));
+
+        ClassEntity savedClass = classRepository.findAll().get(0);
+        assertThat(savedClass.getCreatorId()).isEqualTo(1L);
+        assertThat(savedClass.getTitle()).isEqualTo("Spring Boot 입문");
+        assertThat(savedClass.getDescription()).isEqualTo("백엔드 기본기");
+        assertThat(savedClass.getPrice()).isEqualTo(30000);
+        assertThat(savedClass.getCapacity()).isEqualTo(30);
+        assertThat(savedClass.getEnrolledCount()).isZero();
+        assertThat(savedClass.getStatus()).isEqualTo(ClassStatus.DRAFT);
+    }
+
+    @Test
+    void 학생이_강의를_생성하면_CREATOR_ONLY를_반환한다() throws Exception {
+        mockMvc.perform(post("/api/classes")
+                .header("X-User-Id", "2")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validRequest()))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("CREATOR_ONLY"));
+    }
+
+    @Test
+    void 제목이_비어_있으면_VALIDATION_ERROR를_반환한다() throws Exception {
+        mockMvc.perform(post("/api/classes")
+                .header("X-User-Id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": " ",
+                      "description": "백엔드 기본기",
+                      "price": 30000,
+                      "capacity": 30,
+                      "startDate": "2026-05-01",
+                      "endDate": "2026-05-31"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.fieldErrors[0].field").value("title"));
+    }
+
+    @Test
+    void 가격이_음수면_VALIDATION_ERROR를_반환한다() throws Exception {
+        mockMvc.perform(post("/api/classes")
+                .header("X-User-Id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "Spring Boot 입문",
+                      "description": "백엔드 기본기",
+                      "price": -1,
+                      "capacity": 30,
+                      "startDate": "2026-05-01",
+                      "endDate": "2026-05-31"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.fieldErrors[0].field").value("price"));
+    }
+
+    @Test
+    void 정원이_0_이하면_VALIDATION_ERROR를_반환한다() throws Exception {
+        mockMvc.perform(post("/api/classes")
+                .header("X-User-Id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "Spring Boot 입문",
+                      "description": "백엔드 기본기",
+                      "price": 30000,
+                      "capacity": 0,
+                      "startDate": "2026-05-01",
+                      "endDate": "2026-05-31"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.fieldErrors[0].field").value("capacity"));
+    }
+
+    @Test
+    void 종료일이_시작일보다_빠르면_VALIDATION_ERROR를_반환한다() throws Exception {
+        mockMvc.perform(post("/api/classes")
+                .header("X-User-Id", "1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "Spring Boot 입문",
+                      "description": "백엔드 기본기",
+                      "price": 30000,
+                      "capacity": 30,
+                      "startDate": "2026-05-31",
+                      "endDate": "2026-05-01"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.fieldErrors[0].field").value("endDate"));
+    }
+
+    private String validRequest() {
+        return """
+            {
+              "title": "Spring Boot 입문",
+              "description": "백엔드 기본기",
+              "price": 30000,
+              "capacity": 30,
+              "startDate": "2026-05-01",
+              "endDate": "2026-05-31"
+            }
+            """;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #5 

## 요약
  - 크리에이터 전용 강의 생성 API 추가
  - 강의 생성 시 DRAFT 상태와 작성자 정보를 저장하도록 구현
  - 입력값 및 날짜 범위 검증과 관련 통합 테스트 추가

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
