### PR TITLE
강의 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/be_a/class_/application/ClassDetailView.java
+++ b/src/main/java/com/example/be_a/class_/application/ClassDetailView.java
@@ -1,0 +1,36 @@
+package com.example.be_a.class_.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassStatus;
+import java.time.LocalDate;
+
+public record ClassDetailView(
+    Long id,
+    Long creatorId,
+    String title,
+    String description,
+    int price,
+    int capacity,
+    int enrolledCount,
+    long waitingCount,
+    LocalDate startDate,
+    LocalDate endDate,
+    ClassStatus status
+) {
+
+    public static ClassDetailView from(ClassEntity classEntity, long waitingCount) {
+        return new ClassDetailView(
+            classEntity.getId(),
+            classEntity.getCreatorId(),
+            classEntity.getTitle(),
+            classEntity.getDescription(),
+            classEntity.getPrice(),
+            classEntity.getCapacity(),
+            classEntity.getEnrolledCount(),
+            waitingCount,
+            classEntity.getStartDate(),
+            classEntity.getEndDate(),
+            classEntity.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/example/be_a/class_/application/ClassReadService.java
+++ b/src/main/java/com/example/be_a/class_/application/ClassReadService.java
@@ -1,0 +1,53 @@
+package com.example.be_a.class_.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.infrastructure.EnrollmentCountRepository;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import java.util.List;
+import java.util.Map;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class ClassReadService {
+
+    private final ClassRepository classRepository;
+    private final EnrollmentCountRepository enrollmentCountRepository;
+
+    public ClassReadService(ClassRepository classRepository, EnrollmentCountRepository enrollmentCountRepository) {
+        this.classRepository = classRepository;
+        this.enrollmentCountRepository = enrollmentCountRepository;
+    }
+
+    public Page<ClassSummaryView> list(ClassStatus status, Pageable pageable) {
+        Page<ClassEntity> classPage = status == null
+            ? classRepository.findAll(pageable)
+            : classRepository.findAllByStatus(status, pageable);
+
+        List<Long> classIds = classPage.getContent().stream()
+            .map(ClassEntity::getId)
+            .toList();
+        Map<Long, Long> waitingCounts = enrollmentCountRepository.countWaitingByClassIds(classIds);
+
+        return classPage.map(classEntity -> ClassSummaryView.from(
+            classEntity,
+            waitingCounts.getOrDefault(classEntity.getId(), 0L)
+        ));
+    }
+
+    public ClassDetailView get(Long classId) {
+        ClassEntity classEntity = classRepository.findById(classId)
+            .orElseThrow(() -> new ApiException(ErrorCode.CLASS_NOT_FOUND));
+
+        long waitingCount = enrollmentCountRepository.countWaitingByClassIds(List.of(classId))
+            .getOrDefault(classId, 0L);
+
+        return ClassDetailView.from(classEntity, waitingCount);
+    }
+}

--- a/src/main/java/com/example/be_a/class_/application/ClassSummaryView.java
+++ b/src/main/java/com/example/be_a/class_/application/ClassSummaryView.java
@@ -1,0 +1,29 @@
+package com.example.be_a.class_.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassStatus;
+
+public record ClassSummaryView(
+    Long id,
+    Long creatorId,
+    String title,
+    int price,
+    int capacity,
+    int enrolledCount,
+    long waitingCount,
+    ClassStatus status
+) {
+
+    public static ClassSummaryView from(ClassEntity classEntity, long waitingCount) {
+        return new ClassSummaryView(
+            classEntity.getId(),
+            classEntity.getCreatorId(),
+            classEntity.getTitle(),
+            classEntity.getPrice(),
+            classEntity.getCapacity(),
+            classEntity.getEnrolledCount(),
+            waitingCount,
+            classEntity.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/example/be_a/class_/domain/ClassRepository.java
+++ b/src/main/java/com/example/be_a/class_/domain/ClassRepository.java
@@ -1,6 +1,10 @@
 package com.example.be_a.class_.domain;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
+
+    Page<ClassEntity> findAllByStatus(ClassStatus status, Pageable pageable);
 }

--- a/src/main/java/com/example/be_a/class_/presentation/ClassController.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ClassController.java
@@ -1,25 +1,57 @@
 package com.example.be_a.class_.presentation;
 
 import com.example.be_a.class_.application.ClassCreateService;
+import com.example.be_a.class_.application.ClassReadService;
 import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassStatus;
 import com.example.be_a.global.config.CurrentUser;
+import com.example.be_a.global.support.PageResponse;
 import com.example.be_a.user.application.CurrentUserInfo;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.net.URI;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequestMapping("/api/classes")
 public class ClassController {
 
     private final ClassCreateService classCreateService;
+    private final ClassReadService classReadService;
 
-    public ClassController(ClassCreateService classCreateService) {
+    public ClassController(ClassCreateService classCreateService, ClassReadService classReadService) {
         this.classCreateService = classCreateService;
+        this.classReadService = classReadService;
+    }
+
+    @GetMapping
+    public PageResponse<ClassSummaryResponse> list(
+        @RequestParam(defaultValue = "0") @Min(value = 0, message = "페이지는 0 이상이어야 합니다.") int page,
+        @RequestParam(defaultValue = "20") @Min(value = 1, message = "size는 1 이상이어야 합니다.")
+        @Max(value = 100, message = "size는 100 이하여야 합니다.") int size,
+        @RequestParam(required = false) ClassStatus status
+    ) {
+        return PageResponse.of(classReadService.list(
+            status,
+            PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "id"))
+        ).map(ClassSummaryResponse::from));
+    }
+
+    @GetMapping("/{classId}")
+    public ClassDetailResponse get(@PathVariable Long classId) {
+        return ClassDetailResponse.from(classReadService.get(classId));
     }
 
     @PostMapping

--- a/src/main/java/com/example/be_a/class_/presentation/ClassDetailResponse.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ClassDetailResponse.java
@@ -1,0 +1,36 @@
+package com.example.be_a.class_.presentation;
+
+import com.example.be_a.class_.application.ClassDetailView;
+import com.example.be_a.class_.domain.ClassStatus;
+import java.time.LocalDate;
+
+public record ClassDetailResponse(
+    Long id,
+    Long creatorId,
+    String title,
+    String description,
+    int price,
+    int capacity,
+    int enrolledCount,
+    long waitingCount,
+    LocalDate startDate,
+    LocalDate endDate,
+    ClassStatus status
+) {
+
+    public static ClassDetailResponse from(ClassDetailView detailView) {
+        return new ClassDetailResponse(
+            detailView.id(),
+            detailView.creatorId(),
+            detailView.title(),
+            detailView.description(),
+            detailView.price(),
+            detailView.capacity(),
+            detailView.enrolledCount(),
+            detailView.waitingCount(),
+            detailView.startDate(),
+            detailView.endDate(),
+            detailView.status()
+        );
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/ClassSummaryResponse.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ClassSummaryResponse.java
@@ -1,0 +1,29 @@
+package com.example.be_a.class_.presentation;
+
+import com.example.be_a.class_.application.ClassSummaryView;
+import com.example.be_a.class_.domain.ClassStatus;
+
+public record ClassSummaryResponse(
+    Long id,
+    Long creatorId,
+    String title,
+    int price,
+    int capacity,
+    int enrolledCount,
+    long waitingCount,
+    ClassStatus status
+) {
+
+    public static ClassSummaryResponse from(ClassSummaryView summaryView) {
+        return new ClassSummaryResponse(
+            summaryView.id(),
+            summaryView.creatorId(),
+            summaryView.title(),
+            summaryView.price(),
+            summaryView.capacity(),
+            summaryView.enrolledCount(),
+            summaryView.waitingCount(),
+            summaryView.status()
+        );
+    }
+}

--- a/src/main/java/com/example/be_a/enrollment/domain/EnrollmentStatus.java
+++ b/src/main/java/com/example/be_a/enrollment/domain/EnrollmentStatus.java
@@ -1,0 +1,8 @@
+package com.example.be_a.enrollment.domain;
+
+public enum EnrollmentStatus {
+    WAITING,
+    PENDING,
+    CONFIRMED,
+    CANCELLED
+}

--- a/src/main/java/com/example/be_a/enrollment/infrastructure/EnrollmentCountRepository.java
+++ b/src/main/java/com/example/be_a/enrollment/infrastructure/EnrollmentCountRepository.java
@@ -1,0 +1,46 @@
+package com.example.be_a.enrollment.infrastructure;
+
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class EnrollmentCountRepository {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public EnrollmentCountRepository(NamedParameterJdbcTemplate namedParameterJdbcTemplate) {
+        this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
+    }
+
+    public Map<Long, Long> countWaitingByClassIds(List<Long> classIds) {
+        if (classIds.isEmpty()) {
+            return Map.of();
+        }
+
+        String sql = """
+            SELECT class_id, COUNT(*) AS waiting_count
+            FROM enrollments
+            WHERE status = :status
+              AND class_id IN (:classIds)
+            GROUP BY class_id
+            """;
+
+        MapSqlParameterSource parameters = new MapSqlParameterSource()
+            .addValue("status", EnrollmentStatus.WAITING.name())
+            .addValue("classIds", classIds);
+
+        return namedParameterJdbcTemplate.query(sql, parameters, resultSet -> {
+            Map<Long, Long> counts = new HashMap<>();
+            while (resultSet.next()) {
+                counts.put(resultSet.getLong("class_id"), resultSet.getLong("waiting_count"));
+            }
+            return counts;
+        });
+    }
+}

--- a/src/main/java/com/example/be_a/global/support/PageResponse.java
+++ b/src/main/java/com/example/be_a/global/support/PageResponse.java
@@ -1,0 +1,25 @@
+package com.example.be_a.global.support;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageResponse<T>(
+    List<T> items,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean hasNext
+) {
+
+    public static <T> PageResponse<T> of(Page<T> page) {
+        return new PageResponse<>(
+            page.getContent(),
+            page.getNumber(),
+            page.getSize(),
+            page.getTotalElements(),
+            page.getTotalPages(),
+            page.hasNext()
+        );
+    }
+}

--- a/src/test/java/com/example/be_a/class_/ClassReadIntegrationTest.java
+++ b/src/test/java/com/example/be_a/class_/ClassReadIntegrationTest.java
@@ -1,0 +1,187 @@
+package com.example.be_a.class_;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ClassReadIntegrationTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
+        ensureUser(11L, "student11@example.com", "Student Eleven", "STUDENT");
+        ensureUser(12L, "student12@example.com", "Student Twelve", "STUDENT");
+        jdbcTemplate.update("DELETE FROM enrollments");
+        classRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 강의_목록을_조회할_수_있다() throws Exception {
+        ClassEntity firstClass = saveClass("Spring Boot 입문");
+        ClassEntity secondClass = saveClass("JPA 심화");
+        updateEnrolledCount(firstClass.getId(), 2);
+        insertWaitingEnrollment(firstClass.getId(), 11L);
+        insertWaitingEnrollment(firstClass.getId(), 12L);
+
+        mockMvc.perform(get("/api/classes"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items.length()").value(2))
+            .andExpect(jsonPath("$.page").value(0))
+            .andExpect(jsonPath("$.size").value(20))
+            .andExpect(jsonPath("$.totalElements").value(2))
+            .andExpect(jsonPath("$.totalPages").value(1))
+            .andExpect(jsonPath("$.hasNext").value(false))
+            .andExpect(jsonPath("$.items[0].id").value(secondClass.getId()))
+            .andExpect(jsonPath("$.items[0].title").value("JPA 심화"))
+            .andExpect(jsonPath("$.items[1].id").value(firstClass.getId()))
+            .andExpect(jsonPath("$.items[1].enrolledCount").value(2))
+            .andExpect(jsonPath("$.items[1].waitingCount").value(2))
+            .andExpect(jsonPath("$.items[1].status").value("DRAFT"));
+    }
+
+    @Test
+    void 상태로_필터링한_강의_목록을_조회할_수_있다() throws Exception {
+        ClassEntity openClass = saveClass("Open 강의");
+        saveClass("Draft 강의");
+        updateStatus(openClass.getId(), ClassStatus.OPEN);
+
+        mockMvc.perform(get("/api/classes").param("status", "OPEN"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items.length()").value(1))
+            .andExpect(jsonPath("$.items[0].id").value(openClass.getId()))
+            .andExpect(jsonPath("$.items[0].status").value("OPEN"));
+    }
+
+    @Test
+    void 페이지와_사이즈를_적용한_강의_목록을_조회할_수_있다() throws Exception {
+        saveClass("강의 1");
+        ClassEntity secondClass = saveClass("강의 2");
+        saveClass("강의 3");
+
+        mockMvc.perform(get("/api/classes")
+                .param("page", "1")
+                .param("size", "1"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items.length()").value(1))
+            .andExpect(jsonPath("$.page").value(1))
+            .andExpect(jsonPath("$.size").value(1))
+            .andExpect(jsonPath("$.totalElements").value(3))
+            .andExpect(jsonPath("$.totalPages").value(3))
+            .andExpect(jsonPath("$.hasNext").value(true))
+            .andExpect(jsonPath("$.items[0].id").value(secondClass.getId()));
+    }
+
+    @Test
+    void 사이즈가_100을_초과하면_VALIDATION_ERROR를_반환한다() throws Exception {
+        mockMvc.perform(get("/api/classes").param("size", "101"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void 페이지가_음수면_VALIDATION_ERROR를_반환한다() throws Exception {
+        mockMvc.perform(get("/api/classes").param("page", "-1"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    void 사이즈가_0이면_VALIDATION_ERROR를_반환한다() throws Exception {
+        mockMvc.perform(get("/api/classes").param("size", "0"))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+
+    @Test
+    void 강의_상세를_조회할_수_있다() throws Exception {
+        ClassEntity classEntity = saveClass("Spring Boot 입문");
+        updateEnrolledCount(classEntity.getId(), 3);
+        updateStatus(classEntity.getId(), ClassStatus.OPEN);
+        insertWaitingEnrollment(classEntity.getId(), 11L);
+        insertWaitingEnrollment(classEntity.getId(), 12L);
+
+        mockMvc.perform(get("/api/classes/{classId}", classEntity.getId()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(classEntity.getId()))
+            .andExpect(jsonPath("$.creatorId").value(10))
+            .andExpect(jsonPath("$.title").value("Spring Boot 입문"))
+            .andExpect(jsonPath("$.description").value("백엔드 기본기"))
+            .andExpect(jsonPath("$.price").value(30000))
+            .andExpect(jsonPath("$.capacity").value(30))
+            .andExpect(jsonPath("$.enrolledCount").value(3))
+            .andExpect(jsonPath("$.waitingCount").value(2))
+            .andExpect(jsonPath("$.startDate").value("2026-05-01"))
+            .andExpect(jsonPath("$.endDate").value("2026-05-31"))
+            .andExpect(jsonPath("$.status").value("OPEN"));
+    }
+
+    @Test
+    void 존재하지_않는_강의면_CLASS_NOT_FOUND를_반환한다() throws Exception {
+        mockMvc.perform(get("/api/classes/{classId}", 999L))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
+    }
+
+    private void ensureUser(Long id, String email, String name, String role) {
+        jdbcTemplate.update("""
+            INSERT INTO users (id, email, name, role)
+            VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE email = VALUES(email), name = VALUES(name), role = VALUES(role)
+            """, id, email, name, role);
+    }
+
+    private ClassEntity saveClass(String title) {
+        return classRepository.save(ClassEntity.createDraft(
+            10L,
+            title,
+            "백엔드 기본기",
+            30000,
+            30,
+            java.time.LocalDate.of(2026, 5, 1),
+            java.time.LocalDate.of(2026, 5, 31)
+        ));
+    }
+
+    private void updateStatus(Long classId, ClassStatus status) {
+        jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", status.name(), classId);
+    }
+
+    private void updateEnrolledCount(Long classId, int enrolledCount) {
+        jdbcTemplate.update("UPDATE classes SET enrolled_count = ? WHERE id = ?", enrolledCount, classId);
+    }
+
+    private void insertWaitingEnrollment(Long classId, Long userId) {
+        jdbcTemplate.update(
+            "INSERT INTO enrollments (class_id, user_id, status) VALUES (?, ?, ?)",
+            classId,
+            userId,
+            "WAITING"
+        );
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #7 

## 요약
  - 강의 목록 조회 API 추가
  - 상태 필터, 페이지네이션, 상세 조회 응답 구현
  - waitingCount 계산과 조회 정책 검증 테스트 추가

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
