### PR TITLE
강의 수정 기능 추가

### DIFF
--- a/src/main/java/com/example/be_a/class_/application/ClassUpdateService.java
+++ b/src/main/java/com/example/be_a/class_/application/ClassUpdateService.java
@@ -1,0 +1,78 @@
+package com.example.be_a.class_.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.class_.domain.UpdateClassCommand;
+import com.example.be_a.enrollment.infrastructure.EnrollmentCountRepository;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ApiValidationException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.application.UserAuthorizationService;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ClassUpdateService {
+
+    private final ClassRepository classRepository;
+    private final UserAuthorizationService userAuthorizationService;
+    private final EnrollmentCountRepository enrollmentCountRepository;
+
+    public ClassUpdateService(
+        ClassRepository classRepository,
+        UserAuthorizationService userAuthorizationService,
+        EnrollmentCountRepository enrollmentCountRepository
+    ) {
+        this.classRepository = classRepository;
+        this.userAuthorizationService = userAuthorizationService;
+        this.enrollmentCountRepository = enrollmentCountRepository;
+    }
+
+    @Transactional
+    public ClassDetailView update(Long classId, CurrentUserInfo user, UpdateClassCommand command) {
+        userAuthorizationService.requireCreator(user);
+
+        ClassEntity classEntity = classRepository.findById(classId)
+            .orElseThrow(() -> new ApiException(ErrorCode.CLASS_NOT_FOUND));
+
+        userAuthorizationService.requireOwner(user, classEntity.getCreatorId());
+
+        if (classEntity.getStatus() == ClassStatus.CLOSED) {
+            throw new ApiException(ErrorCode.CLASS_UPDATE_NOT_ALLOWED);
+        }
+
+        updateClass(classEntity, command);
+
+        long waitingCount = enrollmentCountRepository.countWaitingByClassIds(List.of(classId))
+            .getOrDefault(classId, 0L);
+        return ClassDetailView.from(classEntity, waitingCount);
+    }
+
+    private void updateClass(ClassEntity classEntity, UpdateClassCommand command) {
+        validateDateRange(classEntity, command);
+        validateCapacity(classEntity, command);
+        classEntity.applyUpdate(command);
+    }
+
+    private void validateDateRange(ClassEntity classEntity, UpdateClassCommand command) {
+        LocalDate startDate = command.hasStartDate() ? command.startDate() : classEntity.getStartDate();
+        LocalDate endDate = command.hasEndDate() ? command.endDate() : classEntity.getEndDate();
+
+        if (endDate.isBefore(startDate)) {
+            throw ApiValidationException.of("endDate", "종료일은 시작일보다 빠를 수 없습니다.");
+        }
+    }
+
+    private void validateCapacity(ClassEntity classEntity, UpdateClassCommand command) {
+        if (!command.hasCapacity()) {
+            return;
+        }
+        if (command.capacity() < classEntity.getEnrolledCount()) {
+            throw ApiValidationException.of("capacity", "정원은 현재 신청 인원보다 작을 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/be_a/class_/domain/ClassEntity.java
+++ b/src/main/java/com/example/be_a/class_/domain/ClassEntity.java
@@ -1,5 +1,4 @@
 package com.example.be_a.class_.domain;
-
 import com.example.be_a.global.support.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -83,5 +82,26 @@ public class ClassEntity extends BaseEntity {
         LocalDate endDate
     ) {
         return new ClassEntity(creatorId, title, description, price, capacity, startDate, endDate, ClassStatus.DRAFT);
+    }
+
+    public void applyUpdate(UpdateClassCommand command) {
+        if (command.hasTitle()) {
+            this.title = command.title();
+        }
+        if (command.hasDescription()) {
+            this.description = command.description();
+        }
+        if (command.hasPrice()) {
+            this.price = command.price();
+        }
+        if (command.hasCapacity()) {
+            this.capacity = command.capacity();
+        }
+        if (command.hasStartDate()) {
+            this.startDate = command.startDate();
+        }
+        if (command.hasEndDate()) {
+            this.endDate = command.endDate();
+        }
     }
 }

--- a/src/main/java/com/example/be_a/class_/domain/UpdateClassCommand.java
+++ b/src/main/java/com/example/be_a/class_/domain/UpdateClassCommand.java
@@ -1,0 +1,43 @@
+package com.example.be_a.class_.domain;
+
+import java.time.LocalDate;
+
+public record UpdateClassCommand(
+    String title,
+    boolean titlePresent,
+    String description,
+    boolean descriptionPresent,
+    Integer price,
+    boolean pricePresent,
+    Integer capacity,
+    boolean capacityPresent,
+    LocalDate startDate,
+    boolean startDatePresent,
+    LocalDate endDate,
+    boolean endDatePresent
+) {
+
+    public boolean hasTitle() {
+        return titlePresent;
+    }
+
+    public boolean hasDescription() {
+        return descriptionPresent;
+    }
+
+    public boolean hasPrice() {
+        return pricePresent;
+    }
+
+    public boolean hasCapacity() {
+        return capacityPresent;
+    }
+
+    public boolean hasStartDate() {
+        return startDatePresent;
+    }
+
+    public boolean hasEndDate() {
+        return endDatePresent;
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/ClassController.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ClassController.java
@@ -2,6 +2,7 @@ package com.example.be_a.class_.presentation;
 
 import com.example.be_a.class_.application.ClassCreateService;
 import com.example.be_a.class_.application.ClassReadService;
+import com.example.be_a.class_.application.ClassUpdateService;
 import com.example.be_a.class_.domain.ClassEntity;
 import com.example.be_a.class_.domain.ClassStatus;
 import com.example.be_a.global.config.CurrentUser;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -30,10 +32,16 @@ public class ClassController {
 
     private final ClassCreateService classCreateService;
     private final ClassReadService classReadService;
+    private final ClassUpdateService classUpdateService;
 
-    public ClassController(ClassCreateService classCreateService, ClassReadService classReadService) {
+    public ClassController(
+        ClassCreateService classCreateService,
+        ClassReadService classReadService,
+        ClassUpdateService classUpdateService
+    ) {
         this.classCreateService = classCreateService;
         this.classReadService = classReadService;
+        this.classUpdateService = classUpdateService;
     }
 
     @GetMapping
@@ -52,6 +60,15 @@ public class ClassController {
     @GetMapping("/{classId}")
     public ClassDetailResponse get(@PathVariable Long classId) {
         return ClassDetailResponse.from(classReadService.get(classId));
+    }
+
+    @PatchMapping("/{classId}")
+    public ClassDetailResponse update(
+        @PathVariable Long classId,
+        @CurrentUser CurrentUserInfo user,
+        @Valid @RequestBody UpdateClassRequest request
+    ) {
+        return ClassDetailResponse.from(classUpdateService.update(classId, user, request.toCommand()));
     }
 
     @PostMapping

--- a/src/main/java/com/example/be_a/class_/presentation/UpdateClassRequest.java
+++ b/src/main/java/com/example/be_a/class_/presentation/UpdateClassRequest.java
@@ -1,0 +1,136 @@
+package com.example.be_a.class_.presentation;
+
+import com.example.be_a.class_.domain.UpdateClassCommand;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import java.time.LocalDate;
+
+@ValidUpdateClassRequest
+public class UpdateClassRequest {
+
+    private String title;
+    private String description;
+    private Integer price;
+    private Integer capacity;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    @JsonIgnore
+    private boolean titlePresent;
+
+    @JsonIgnore
+    private boolean descriptionPresent;
+
+    @JsonIgnore
+    private boolean pricePresent;
+
+    @JsonIgnore
+    private boolean capacityPresent;
+
+    @JsonIgnore
+    private boolean startDatePresent;
+
+    @JsonIgnore
+    private boolean endDatePresent;
+
+    public String getTitle() {
+        return title;
+    }
+
+    @JsonSetter("title")
+    public void setTitle(String title) {
+        this.title = title;
+        this.titlePresent = true;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonSetter("description")
+    public void setDescription(String description) {
+        this.description = description;
+        this.descriptionPresent = true;
+    }
+
+    public Integer getPrice() {
+        return price;
+    }
+
+    @JsonSetter("price")
+    public void setPrice(Integer price) {
+        this.price = price;
+        this.pricePresent = true;
+    }
+
+    public Integer getCapacity() {
+        return capacity;
+    }
+
+    @JsonSetter("capacity")
+    public void setCapacity(Integer capacity) {
+        this.capacity = capacity;
+        this.capacityPresent = true;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @JsonSetter("startDate")
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+        this.startDatePresent = true;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    @JsonSetter("endDate")
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+        this.endDatePresent = true;
+    }
+
+    public boolean hasTitle() {
+        return titlePresent;
+    }
+
+    public boolean hasDescription() {
+        return descriptionPresent;
+    }
+
+    public boolean hasPrice() {
+        return pricePresent;
+    }
+
+    public boolean hasCapacity() {
+        return capacityPresent;
+    }
+
+    public boolean hasStartDate() {
+        return startDatePresent;
+    }
+
+    public boolean hasEndDate() {
+        return endDatePresent;
+    }
+
+    public UpdateClassCommand toCommand() {
+        return new UpdateClassCommand(
+            title,
+            titlePresent,
+            description,
+            descriptionPresent,
+            price,
+            pricePresent,
+            capacity,
+            capacityPresent,
+            startDate,
+            startDatePresent,
+            endDate,
+            endDatePresent
+        );
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/UpdateClassRequestValidator.java
+++ b/src/main/java/com/example/be_a/class_/presentation/UpdateClassRequestValidator.java
@@ -1,0 +1,112 @@
+package com.example.be_a.class_.presentation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class UpdateClassRequestValidator implements ConstraintValidator<ValidUpdateClassRequest, UpdateClassRequest> {
+
+    @Override
+    public boolean isValid(UpdateClassRequest value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+
+        boolean valid = true;
+        context.disableDefaultConstraintViolation();
+
+        valid &= validateTitle(value, context);
+        valid &= validateDescription(value, context);
+        valid &= validatePrice(value, context);
+        valid &= validateCapacity(value, context);
+        valid &= validateStartDate(value, context);
+        valid &= validateEndDate(value, context);
+        valid &= validateDateRange(value, context);
+
+        return valid;
+    }
+
+    private boolean validateTitle(UpdateClassRequest value, ConstraintValidatorContext context) {
+        if (!value.hasTitle()) {
+            return true;
+        }
+        if (value.getTitle() != null && !value.getTitle().isBlank()) {
+            return true;
+        }
+        addViolation(context, "title", "제목은 필수입니다.");
+        return false;
+    }
+
+    private boolean validateDescription(UpdateClassRequest value, ConstraintValidatorContext context) {
+        if (!value.hasDescription() || value.getDescription() != null) {
+            return true;
+        }
+        addViolation(context, "description", "설명은 null일 수 없습니다.");
+        return false;
+    }
+
+    private boolean validatePrice(UpdateClassRequest value, ConstraintValidatorContext context) {
+        if (!value.hasPrice()) {
+            return true;
+        }
+        if (value.getPrice() == null) {
+            addViolation(context, "price", "가격은 필수입니다.");
+            return false;
+        }
+        if (value.getPrice() >= 0) {
+            return true;
+        }
+        addViolation(context, "price", "가격은 0 이상이어야 합니다.");
+        return false;
+    }
+
+    private boolean validateCapacity(UpdateClassRequest value, ConstraintValidatorContext context) {
+        if (!value.hasCapacity()) {
+            return true;
+        }
+        if (value.getCapacity() == null) {
+            addViolation(context, "capacity", "정원은 필수입니다.");
+            return false;
+        }
+        if (value.getCapacity() >= 1) {
+            return true;
+        }
+        addViolation(context, "capacity", "정원은 1 이상이어야 합니다.");
+        return false;
+    }
+
+    private boolean validateStartDate(UpdateClassRequest value, ConstraintValidatorContext context) {
+        if (!value.hasStartDate() || value.getStartDate() != null) {
+            return true;
+        }
+        addViolation(context, "startDate", "시작일은 필수입니다.");
+        return false;
+    }
+
+    private boolean validateEndDate(UpdateClassRequest value, ConstraintValidatorContext context) {
+        if (!value.hasEndDate() || value.getEndDate() != null) {
+            return true;
+        }
+        addViolation(context, "endDate", "종료일은 필수입니다.");
+        return false;
+    }
+
+    private boolean validateDateRange(UpdateClassRequest value, ConstraintValidatorContext context) {
+        if (!value.hasStartDate() || !value.hasEndDate()) {
+            return true;
+        }
+        if (value.getStartDate() == null || value.getEndDate() == null) {
+            return true;
+        }
+        if (!value.getEndDate().isBefore(value.getStartDate())) {
+            return true;
+        }
+        addViolation(context, "endDate", "종료일은 시작일보다 빠를 수 없습니다.");
+        return false;
+    }
+
+    private void addViolation(ConstraintValidatorContext context, String field, String message) {
+        context.buildConstraintViolationWithTemplate(message)
+            .addPropertyNode(field)
+            .addConstraintViolation();
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/ValidUpdateClassRequest.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ValidUpdateClassRequest.java
@@ -1,0 +1,20 @@
+package com.example.be_a.class_.presentation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = UpdateClassRequestValidator.class)
+public @interface ValidUpdateClassRequest {
+
+    String message() default "강의 수정 요청이 올바르지 않습니다.";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/be_a/global/error/ApiValidationException.java
+++ b/src/main/java/com/example/be_a/global/error/ApiValidationException.java
@@ -1,0 +1,21 @@
+package com.example.be_a.global.error;
+
+import java.util.List;
+
+public class ApiValidationException extends RuntimeException {
+
+    private final List<FieldErrorDetail> fieldErrors;
+
+    private ApiValidationException(List<FieldErrorDetail> fieldErrors) {
+        super(ErrorCode.VALIDATION_ERROR.getMessage());
+        this.fieldErrors = List.copyOf(fieldErrors);
+    }
+
+    public static ApiValidationException of(String field, String reason) {
+        return new ApiValidationException(List.of(new FieldErrorDetail(field, reason)));
+    }
+
+    public List<FieldErrorDetail> getFieldErrors() {
+        return fieldErrors;
+    }
+}

--- a/src/main/java/com/example/be_a/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/be_a/global/error/GlobalExceptionHandler.java
@@ -22,6 +22,15 @@ public class GlobalExceptionHandler {
             .body(ErrorResponse.of(errorCode, request.getRequestURI()));
     }
 
+    @ExceptionHandler(ApiValidationException.class)
+    public ResponseEntity<ErrorResponse> handleApiValidationException(
+        ApiValidationException exception,
+        HttpServletRequest request
+    ) {
+        return ResponseEntity.badRequest()
+            .body(ErrorResponse.of(ErrorCode.VALIDATION_ERROR, request.getRequestURI(), exception.getFieldErrors()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(
         MethodArgumentNotValidException exception,

--- a/src/test/java/com/example/be_a/class_/ClassUpdateIntegrationTest.java
+++ b/src/test/java/com/example/be_a/class_/ClassUpdateIntegrationTest.java
@@ -1,0 +1,242 @@
+package com.example.be_a.class_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ClassUpdateIntegrationTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
+        ensureUser(20L, "creator20@example.com", "Creator Twenty", "CREATOR");
+        jdbcTemplate.update("DELETE FROM enrollments");
+        classRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void DRAFT_강의는_전체_필드를_수정할_수_있다() throws Exception {
+        ClassEntity classEntity = saveDraftClass(10L, "기존 제목");
+
+        mockMvc.perform(patch("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "수정된 제목",
+                      "description": "수정된 설명",
+                      "price": 45000,
+                      "capacity": 40,
+                      "startDate": "2026-06-01",
+                      "endDate": "2026-06-30"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(classEntity.getId()))
+            .andExpect(jsonPath("$.title").value("수정된 제목"))
+            .andExpect(jsonPath("$.description").value("수정된 설명"))
+            .andExpect(jsonPath("$.price").value(45000))
+            .andExpect(jsonPath("$.capacity").value(40))
+            .andExpect(jsonPath("$.startDate").value("2026-06-01"))
+            .andExpect(jsonPath("$.endDate").value("2026-06-30"))
+            .andExpect(jsonPath("$.status").value("DRAFT"));
+
+        ClassEntity updatedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        assertThat(updatedClass.getTitle()).isEqualTo("수정된 제목");
+        assertThat(updatedClass.getDescription()).isEqualTo("수정된 설명");
+        assertThat(updatedClass.getPrice()).isEqualTo(45000);
+        assertThat(updatedClass.getCapacity()).isEqualTo(40);
+        assertThat(updatedClass.getStartDate()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(updatedClass.getEndDate()).isEqualTo(LocalDate.of(2026, 6, 30));
+    }
+
+    @Test
+    void 요청에_없는_필드는_기존_값을_유지한다() throws Exception {
+        ClassEntity classEntity = saveDraftClass(10L, "기존 제목");
+
+        mockMvc.perform(patch("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "부분 수정 제목"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.title").value("부분 수정 제목"))
+            .andExpect(jsonPath("$.description").value("기존 설명"))
+            .andExpect(jsonPath("$.price").value(30000))
+            .andExpect(jsonPath("$.capacity").value(30))
+            .andExpect(jsonPath("$.startDate").value("2026-05-01"))
+            .andExpect(jsonPath("$.endDate").value("2026-05-31"));
+
+        ClassEntity updatedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        assertThat(updatedClass.getTitle()).isEqualTo("부분 수정 제목");
+        assertThat(updatedClass.getDescription()).isEqualTo("기존 설명");
+        assertThat(updatedClass.getPrice()).isEqualTo(30000);
+        assertThat(updatedClass.getCapacity()).isEqualTo(30);
+        assertThat(updatedClass.getStartDate()).isEqualTo(LocalDate.of(2026, 5, 1));
+        assertThat(updatedClass.getEndDate()).isEqualTo(LocalDate.of(2026, 5, 31));
+    }
+
+    @Test
+    void OPEN_강의도_전체_필드를_수정할_수_있다() throws Exception {
+        ClassEntity classEntity = saveDraftClass(10L, "기존 제목");
+        updateStatus(classEntity.getId(), ClassStatus.OPEN);
+
+        mockMvc.perform(patch("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "열린 강의 제목",
+                      "description": "열린 강의 설명",
+                      "price": 50000,
+                      "capacity": 50,
+                      "startDate": "2026-06-10",
+                      "endDate": "2026-06-20"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.title").value("열린 강의 제목"))
+            .andExpect(jsonPath("$.description").value("열린 강의 설명"))
+            .andExpect(jsonPath("$.price").value(50000))
+            .andExpect(jsonPath("$.capacity").value(50))
+            .andExpect(jsonPath("$.startDate").value("2026-06-10"))
+            .andExpect(jsonPath("$.endDate").value("2026-06-20"))
+            .andExpect(jsonPath("$.status").value("OPEN"));
+
+        ClassEntity updatedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        assertThat(updatedClass.getTitle()).isEqualTo("열린 강의 제목");
+        assertThat(updatedClass.getDescription()).isEqualTo("열린 강의 설명");
+        assertThat(updatedClass.getPrice()).isEqualTo(50000);
+        assertThat(updatedClass.getCapacity()).isEqualTo(50);
+        assertThat(updatedClass.getStartDate()).isEqualTo(LocalDate.of(2026, 6, 10));
+        assertThat(updatedClass.getEndDate()).isEqualTo(LocalDate.of(2026, 6, 20));
+    }
+
+    @Test
+    void 현재_신청_인원보다_작은_정원으로는_수정할_수_없다() throws Exception {
+        ClassEntity classEntity = saveDraftClass(10L, "기존 제목");
+        updateStatus(classEntity.getId(), ClassStatus.OPEN);
+        updateEnrolledCount(classEntity.getId(), 3);
+
+        mockMvc.perform(patch("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "capacity": 2
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.fieldErrors[0].field").value("capacity"));
+    }
+
+    @Test
+    void CLOSED_강의는_수정할_수_없다() throws Exception {
+        ClassEntity classEntity = saveDraftClass(10L, "기존 제목");
+        updateStatus(classEntity.getId(), ClassStatus.CLOSED);
+
+        mockMvc.perform(patch("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "수정 시도"
+                    }
+                    """))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_UPDATE_NOT_ALLOWED"));
+    }
+
+    @Test
+    void 다른_크리에이터의_강의는_수정할_수_없다() throws Exception {
+        ClassEntity classEntity = saveDraftClass(10L, "기존 제목");
+
+        mockMvc.perform(patch("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "title": "수정 시도"
+                    }
+                    """))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    void null을_입력하면_VALIDATION_ERROR를_반환한다() throws Exception {
+        ClassEntity classEntity = saveDraftClass(10L, "기존 제목");
+
+        mockMvc.perform(patch("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "description": null
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.fieldErrors[0].field").value("description"));
+    }
+
+    private void ensureUser(Long id, String email, String name, String role) {
+        jdbcTemplate.update("""
+            INSERT INTO users (id, email, name, role)
+            VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE email = VALUES(email), name = VALUES(name), role = VALUES(role)
+            """, id, email, name, role);
+    }
+
+    private ClassEntity saveDraftClass(Long creatorId, String title) {
+        return classRepository.save(ClassEntity.createDraft(
+            creatorId,
+            title,
+            "기존 설명",
+            30000,
+            30,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        ));
+    }
+
+    private void updateStatus(Long classId, ClassStatus status) {
+        jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", status.name(), classId);
+    }
+
+    private void updateEnrolledCount(Long classId, int enrolledCount) {
+        jdbcTemplate.update("UPDATE classes SET enrolled_count = ? WHERE id = ?", enrolledCount, classId);
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #9 

## 요약
  - 크리에이터 전용 강의 수정 API 추가
  - PATCH 부분 수정 규칙과 CLOSED 수정 차단 정책 반영
  - 공통 검증 예외 처리와 강의 수정 통합 테스트 추가

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
