### PR TITLE
강의 상태 전이 기능 추가

### DIFF
--- a/src/main/java/com/example/be_a/class_/application/ClassStatusChangeService.java
+++ b/src/main/java/com/example/be_a/class_/application/ClassStatusChangeService.java
@@ -1,0 +1,38 @@
+package com.example.be_a.class_.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.application.UserAuthorizationService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ClassStatusChangeService {
+
+    private final ClassRepository classRepository;
+    private final UserAuthorizationService userAuthorizationService;
+
+    public ClassStatusChangeService(
+        ClassRepository classRepository,
+        UserAuthorizationService userAuthorizationService
+    ) {
+        this.classRepository = classRepository;
+        this.userAuthorizationService = userAuthorizationService;
+    }
+
+    @Transactional
+    public ClassEntity changeStatus(Long classId, CurrentUserInfo user, ClassStatus targetStatus) {
+        userAuthorizationService.requireCreator(user);
+
+        ClassEntity classEntity = classRepository.findById(classId)
+            .orElseThrow(() -> new ApiException(ErrorCode.CLASS_NOT_FOUND));
+
+        userAuthorizationService.requireOwner(user, classEntity.getCreatorId());
+        classEntity.changeStatus(targetStatus);
+        return classEntity;
+    }
+}

--- a/src/main/java/com/example/be_a/class_/domain/ClassEntity.java
+++ b/src/main/java/com/example/be_a/class_/domain/ClassEntity.java
@@ -1,4 +1,7 @@
 package com.example.be_a.class_.domain;
+
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
 import com.example.be_a.global.support.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -103,5 +106,19 @@ public class ClassEntity extends BaseEntity {
         if (command.hasEndDate()) {
             this.endDate = command.endDate();
         }
+    }
+
+    public void changeStatus(ClassStatus targetStatus) {
+        if (status == ClassStatus.DRAFT && targetStatus == ClassStatus.OPEN) {
+            this.status = targetStatus;
+            return;
+        }
+
+        if (status == ClassStatus.OPEN && targetStatus == ClassStatus.CLOSED) {
+            this.status = targetStatus;
+            return;
+        }
+
+        throw new ApiException(ErrorCode.INVALID_STATE_TRANSITION);
     }
 }

--- a/src/main/java/com/example/be_a/class_/presentation/ChangeClassStatusRequest.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ChangeClassStatusRequest.java
@@ -1,0 +1,10 @@
+package com.example.be_a.class_.presentation;
+
+import com.example.be_a.class_.domain.ClassStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ChangeClassStatusRequest(
+    @NotNull(message = "변경할 상태는 필수입니다.")
+    ClassStatus targetStatus
+) {
+}

--- a/src/main/java/com/example/be_a/class_/presentation/ChangeClassStatusResponse.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ChangeClassStatusResponse.java
@@ -1,0 +1,14 @@
+package com.example.be_a.class_.presentation;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassStatus;
+
+public record ChangeClassStatusResponse(
+    Long id,
+    ClassStatus status
+) {
+
+    public static ChangeClassStatusResponse from(ClassEntity classEntity) {
+        return new ChangeClassStatusResponse(classEntity.getId(), classEntity.getStatus());
+    }
+}

--- a/src/main/java/com/example/be_a/class_/presentation/ClassController.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ClassController.java
@@ -2,6 +2,7 @@ package com.example.be_a.class_.presentation;
 
 import com.example.be_a.class_.application.ClassCreateService;
 import com.example.be_a.class_.application.ClassReadService;
+import com.example.be_a.class_.application.ClassStatusChangeService;
 import com.example.be_a.class_.application.ClassUpdateService;
 import com.example.be_a.class_.domain.ClassEntity;
 import com.example.be_a.class_.domain.ClassStatus;
@@ -33,15 +34,18 @@ public class ClassController {
     private final ClassCreateService classCreateService;
     private final ClassReadService classReadService;
     private final ClassUpdateService classUpdateService;
+    private final ClassStatusChangeService classStatusChangeService;
 
     public ClassController(
         ClassCreateService classCreateService,
         ClassReadService classReadService,
-        ClassUpdateService classUpdateService
+        ClassUpdateService classUpdateService,
+        ClassStatusChangeService classStatusChangeService
     ) {
         this.classCreateService = classCreateService;
         this.classReadService = classReadService;
         this.classUpdateService = classUpdateService;
+        this.classStatusChangeService = classStatusChangeService;
     }
 
     @GetMapping
@@ -69,6 +73,17 @@ public class ClassController {
         @Valid @RequestBody UpdateClassRequest request
     ) {
         return ClassDetailResponse.from(classUpdateService.update(classId, user, request.toCommand()));
+    }
+
+    @PostMapping("/{classId}/status")
+    public ChangeClassStatusResponse changeStatus(
+        @PathVariable Long classId,
+        @CurrentUser CurrentUserInfo user,
+        @Valid @RequestBody ChangeClassStatusRequest request
+    ) {
+        return ChangeClassStatusResponse.from(
+            classStatusChangeService.changeStatus(classId, user, request.targetStatus())
+        );
     }
 
     @PostMapping

--- a/src/test/java/com/example/be_a/class_/ClassStatusChangeIntegrationTest.java
+++ b/src/test/java/com/example/be_a/class_/ClassStatusChangeIntegrationTest.java
@@ -1,0 +1,191 @@
+package com.example.be_a.class_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ClassStatusChangeIntegrationTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
+        jdbcTemplate.update("DELETE FROM enrollments");
+        classRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void DRAFT에서_OPEN으로_상태를_변경할_수_있다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "상태 전이 강의");
+
+        mockMvc.perform(post("/api/classes/{classId}/status", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "targetStatus": "OPEN"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(classEntity.getId()))
+            .andExpect(jsonPath("$.status").value("OPEN"));
+
+        ClassEntity changedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        assertThat(changedClass.getStatus()).isEqualTo(ClassStatus.OPEN);
+    }
+
+    @Test
+    void OPEN에서_CLOSED로_상태를_변경할_수_있다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "상태 전이 강의");
+        updateStatus(classEntity.getId(), ClassStatus.OPEN);
+
+        mockMvc.perform(post("/api/classes/{classId}/status", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "targetStatus": "CLOSED"
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(classEntity.getId()))
+            .andExpect(jsonPath("$.status").value("CLOSED"));
+
+        ClassEntity changedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        assertThat(changedClass.getStatus()).isEqualTo(ClassStatus.CLOSED);
+    }
+
+    @Test
+    void 학생이_강의_상태를_변경하면_CREATOR_ONLY를_반환한다() throws Exception {
+        ensureUser(11L, "student11@example.com", "Student Eleven", "STUDENT");
+        ClassEntity classEntity = saveClass(10L, "상태 전이 강의");
+
+        mockMvc.perform(post("/api/classes/{classId}/status", classEntity.getId())
+                .header("X-User-Id", "11")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "targetStatus": "OPEN"
+                    }
+                    """))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("CREATOR_ONLY"));
+    }
+
+    @Test
+    void 다른_크리에이터가_강의_상태를_변경하면_FORBIDDEN을_반환한다() throws Exception {
+        ensureUser(20L, "creator20@example.com", "Creator Twenty", "CREATOR");
+        ClassEntity classEntity = saveClass(10L, "상태 전이 강의");
+
+        mockMvc.perform(post("/api/classes/{classId}/status", classEntity.getId())
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "targetStatus": "OPEN"
+                    }
+                    """))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    void DRAFT에서_CLOSED로_상태를_변경하면_INVALID_STATE_TRANSITION을_반환한다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "상태 전이 강의");
+
+        mockMvc.perform(post("/api/classes/{classId}/status", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "targetStatus": "CLOSED"
+                    }
+                    """))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void CLOSED에서_OPEN으로_상태를_변경하면_INVALID_STATE_TRANSITION을_반환한다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "상태 전이 강의");
+        updateStatus(classEntity.getId(), ClassStatus.CLOSED);
+
+        mockMvc.perform(post("/api/classes/{classId}/status", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "targetStatus": "OPEN"
+                    }
+                    """))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void 잘못된_enum_값이면_VALIDATION_ERROR를_반환한다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "상태 전이 강의");
+
+        mockMvc.perform(post("/api/classes/{classId}/status", classEntity.getId())
+                .header("X-User-Id", "10")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "targetStatus": "OPENED"
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+    }
+
+    private void ensureUser(Long id, String email, String name, String role) {
+        jdbcTemplate.update("""
+            INSERT INTO users (id, email, name, role)
+            VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE email = VALUES(email), name = VALUES(name), role = VALUES(role)
+            """, id, email, name, role);
+    }
+
+    private ClassEntity saveClass(Long creatorId, String title) {
+        return classRepository.save(ClassEntity.createDraft(
+            creatorId,
+            title,
+            "설명",
+            30000,
+            30,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        ));
+    }
+
+    private void updateStatus(Long classId, ClassStatus status) {
+        jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", status.name(), classId);
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #11  

## 요약
  - 크리에이터 전용 강의 상태 전이 API 추가
  - DRAFT → OPEN, OPEN → CLOSED 전이 규칙과 예외 처리 반영
  - 상태 전이 권한 검증과 통합 테스트 추가

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
