### PR TITLE
강의 삭제 기능 추가

### DIFF
--- a/src/main/java/com/example/be_a/class_/application/ClassDeleteService.java
+++ b/src/main/java/com/example/be_a/class_/application/ClassDeleteService.java
@@ -1,0 +1,56 @@
+package com.example.be_a.class_.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.infrastructure.EnrollmentCountRepository;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.application.UserAuthorizationService;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class ClassDeleteService {
+
+    private final ClassRepository classRepository;
+    private final UserAuthorizationService userAuthorizationService;
+    private final EnrollmentCountRepository enrollmentCountRepository;
+
+    public ClassDeleteService(
+        ClassRepository classRepository,
+        UserAuthorizationService userAuthorizationService,
+        EnrollmentCountRepository enrollmentCountRepository
+    ) {
+        this.classRepository = classRepository;
+        this.userAuthorizationService = userAuthorizationService;
+        this.enrollmentCountRepository = enrollmentCountRepository;
+    }
+
+    @Transactional
+    public void delete(Long classId, CurrentUserInfo user) {
+        userAuthorizationService.requireCreator(user);
+
+        ClassEntity classEntity = classRepository.findById(classId)
+            .orElseThrow(() -> new ApiException(ErrorCode.CLASS_NOT_FOUND));
+
+        userAuthorizationService.requireOwner(user, classEntity.getCreatorId());
+
+        if (classEntity.getStatus() != ClassStatus.DRAFT) {
+            throw new ApiException(ErrorCode.CLASS_NOT_DRAFT);
+        }
+
+        if (enrollmentCountRepository.countByClassId(classId) > 0) {
+            throw new ApiException(ErrorCode.CLASS_DELETE_NOT_ALLOWED);
+        }
+
+        try {
+            classRepository.delete(classEntity);
+            classRepository.flush();
+        } catch (DataIntegrityViolationException exception) {
+            throw new ApiException(ErrorCode.CLASS_DELETE_NOT_ALLOWED);
+        }
+    }
+}

--- a/src/main/java/com/example/be_a/class_/application/ClassDeleteService.java
+++ b/src/main/java/com/example/be_a/class_/application/ClassDeleteService.java
@@ -42,7 +42,7 @@ public class ClassDeleteService {
             throw new ApiException(ErrorCode.CLASS_NOT_DRAFT);
         }
 
-        if (enrollmentCountRepository.countByClassId(classId) > 0) {
+        if (enrollmentCountRepository.existsByClassId(classId)) {
             throw new ApiException(ErrorCode.CLASS_DELETE_NOT_ALLOWED);
         }
 

--- a/src/main/java/com/example/be_a/class_/presentation/ClassController.java
+++ b/src/main/java/com/example/be_a/class_/presentation/ClassController.java
@@ -1,6 +1,7 @@
 package com.example.be_a.class_.presentation;
 
 import com.example.be_a.class_.application.ClassCreateService;
+import com.example.be_a.class_.application.ClassDeleteService;
 import com.example.be_a.class_.application.ClassReadService;
 import com.example.be_a.class_.application.ClassStatusChangeService;
 import com.example.be_a.class_.application.ClassUpdateService;
@@ -17,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,17 +34,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class ClassController {
 
     private final ClassCreateService classCreateService;
+    private final ClassDeleteService classDeleteService;
     private final ClassReadService classReadService;
     private final ClassUpdateService classUpdateService;
     private final ClassStatusChangeService classStatusChangeService;
 
     public ClassController(
         ClassCreateService classCreateService,
+        ClassDeleteService classDeleteService,
         ClassReadService classReadService,
         ClassUpdateService classUpdateService,
         ClassStatusChangeService classStatusChangeService
     ) {
         this.classCreateService = classCreateService;
+        this.classDeleteService = classDeleteService;
         this.classReadService = classReadService;
         this.classUpdateService = classUpdateService;
         this.classStatusChangeService = classStatusChangeService;
@@ -73,6 +78,15 @@ public class ClassController {
         @Valid @RequestBody UpdateClassRequest request
     ) {
         return ClassDetailResponse.from(classUpdateService.update(classId, user, request.toCommand()));
+    }
+
+    @DeleteMapping("/{classId}")
+    public ResponseEntity<Void> delete(
+        @PathVariable Long classId,
+        @CurrentUser CurrentUserInfo user
+    ) {
+        classDeleteService.delete(classId, user);
+        return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/{classId}/status")

--- a/src/main/java/com/example/be_a/enrollment/infrastructure/EnrollmentCountRepository.java
+++ b/src/main/java/com/example/be_a/enrollment/infrastructure/EnrollmentCountRepository.java
@@ -18,18 +18,20 @@ public class EnrollmentCountRepository {
         this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
     }
 
-    public long countByClassId(Long classId) {
+    public boolean existsByClassId(Long classId) {
         String sql = """
-            SELECT COUNT(*)
-            FROM enrollments
-            WHERE class_id = :classId
+            SELECT EXISTS(
+                SELECT 1
+                FROM enrollments
+                WHERE class_id = :classId
+            )
             """;
 
         MapSqlParameterSource parameters = new MapSqlParameterSource()
             .addValue("classId", classId);
 
-        Long count = namedParameterJdbcTemplate.queryForObject(sql, parameters, Long.class);
-        return count == null ? 0L : count;
+        Boolean exists = namedParameterJdbcTemplate.queryForObject(sql, parameters, Boolean.class);
+        return Boolean.TRUE.equals(exists);
     }
 
     public Map<Long, Long> countWaitingByClassIds(List<Long> classIds) {

--- a/src/main/java/com/example/be_a/enrollment/infrastructure/EnrollmentCountRepository.java
+++ b/src/main/java/com/example/be_a/enrollment/infrastructure/EnrollmentCountRepository.java
@@ -18,6 +18,20 @@ public class EnrollmentCountRepository {
         this.namedParameterJdbcTemplate = namedParameterJdbcTemplate;
     }
 
+    public long countByClassId(Long classId) {
+        String sql = """
+            SELECT COUNT(*)
+            FROM enrollments
+            WHERE class_id = :classId
+            """;
+
+        MapSqlParameterSource parameters = new MapSqlParameterSource()
+            .addValue("classId", classId);
+
+        Long count = namedParameterJdbcTemplate.queryForObject(sql, parameters, Long.class);
+        return count == null ? 0L : count;
+    }
+
     public Map<Long, Long> countWaitingByClassIds(List<Long> classIds) {
         if (classIds.isEmpty()) {
             return Map.of();

--- a/src/test/java/com/example/be_a/class_/ClassDeleteIntegrationTest.java
+++ b/src/test/java/com/example/be_a/class_/ClassDeleteIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.example.be_a.class_;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ClassDeleteIntegrationTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
+        ensureUser(20L, "creator20@example.com", "Creator Twenty", "CREATOR");
+        ensureUser(30L, "student30@example.com", "Student Thirty", "STUDENT");
+        jdbcTemplate.update("DELETE FROM enrollments");
+        classRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void DRAFT_강의는_삭제할_수_있다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "삭제 대상 강의");
+
+        mockMvc.perform(delete("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10"))
+            .andExpect(status().isNoContent());
+
+        assertThat(classRepository.findById(classEntity.getId())).isEmpty();
+    }
+
+    @Test
+    void OPEN_강의는_삭제할_수_없다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "삭제 대상 강의");
+        updateStatus(classEntity.getId(), ClassStatus.OPEN);
+
+        mockMvc.perform(delete("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_NOT_DRAFT"));
+    }
+
+    @Test
+    void CLOSED_강의는_삭제할_수_없다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "삭제 대상 강의");
+        updateStatus(classEntity.getId(), ClassStatus.CLOSED);
+
+        mockMvc.perform(delete("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_NOT_DRAFT"));
+    }
+
+    @Test
+    void 다른_크리에이터의_강의는_삭제할_수_없다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "삭제 대상 강의");
+
+        mockMvc.perform(delete("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "20"))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    void 학생은_강의를_삭제할_수_없다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "삭제 대상 강의");
+
+        mockMvc.perform(delete("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "30"))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("CREATOR_ONLY"));
+    }
+
+    @Test
+    void 존재하지_않는_강의는_CLASS_NOT_FOUND를_반환한다() throws Exception {
+        mockMvc.perform(delete("/api/classes/{classId}", 99999L)
+                .header("X-User-Id", "10"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("CLASS_NOT_FOUND"));
+    }
+
+    @Test
+    void enrollment가_존재하면_강의를_삭제할_수_없다() throws Exception {
+        ClassEntity classEntity = saveClass(10L, "삭제 대상 강의");
+        insertEnrollment(classEntity.getId(), 30L, "CANCELLED");
+
+        mockMvc.perform(delete("/api/classes/{classId}", classEntity.getId())
+                .header("X-User-Id", "10"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_DELETE_NOT_ALLOWED"));
+    }
+
+    private void ensureUser(Long id, String email, String name, String role) {
+        jdbcTemplate.update("""
+            INSERT INTO users (id, email, name, role)
+            VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE email = VALUES(email), name = VALUES(name), role = VALUES(role)
+            """, id, email, name, role);
+    }
+
+    private ClassEntity saveClass(Long creatorId, String title) {
+        return classRepository.save(ClassEntity.createDraft(
+            creatorId,
+            title,
+            "설명",
+            30000,
+            30,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        ));
+    }
+
+    private void updateStatus(Long classId, ClassStatus status) {
+        jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", status.name(), classId);
+    }
+
+    private void insertEnrollment(Long classId, Long userId, String status) {
+        jdbcTemplate.update("""
+            INSERT INTO enrollments (class_id, user_id, status)
+            VALUES (?, ?, ?)
+            """, classId, userId, status);
+    }
+}

--- a/src/test/java/com/example/be_a/class_/ClassDeleteIntegrationTest.java
+++ b/src/test/java/com/example/be_a/class_/ClassDeleteIntegrationTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.be_a.class_.domain.ClassEntity;
 import com.example.be_a.class_.domain.ClassRepository;
 import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
 import com.example.be_a.support.MySqlTestContainerSupport;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -106,7 +107,7 @@ class ClassDeleteIntegrationTest extends MySqlTestContainerSupport {
     @Test
     void enrollment가_존재하면_강의를_삭제할_수_없다() throws Exception {
         ClassEntity classEntity = saveClass(10L, "삭제 대상 강의");
-        insertEnrollment(classEntity.getId(), 30L, "CANCELLED");
+        insertEnrollment(classEntity.getId(), 30L, EnrollmentStatus.CANCELLED);
 
         mockMvc.perform(delete("/api/classes/{classId}", classEntity.getId())
                 .header("X-User-Id", "10"))
@@ -138,10 +139,10 @@ class ClassDeleteIntegrationTest extends MySqlTestContainerSupport {
         jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", status.name(), classId);
     }
 
-    private void insertEnrollment(Long classId, Long userId, String status) {
+    private void insertEnrollment(Long classId, Long userId, EnrollmentStatus status) {
         jdbcTemplate.update("""
             INSERT INTO enrollments (class_id, user_id, status)
             VALUES (?, ?, ?)
-            """, classId, userId, status);
+            """, classId, userId, status.name());
     }
 }


### PR DESCRIPTION
## 연관 이슈
- Closes #13 

## 요약
  - 크리에이터 전용 강의 삭제 API 추가
  - DRAFT 상태와 enrollment 존재 여부 기반 삭제 정책 반영
  - 강의 삭제 권한 검증과 통합 테스트 추가

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
