### PR TITLE
수강 신청 기능 구현

### DIFF
--- a/src/main/java/com/example/be_a/class_/domain/ClassRepository.java
+++ b/src/main/java/com/example/be_a/class_/domain/ClassRepository.java
@@ -3,8 +3,21 @@ package com.example.be_a.class_.domain;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
 
     Page<ClassEntity> findAllByStatus(ClassStatus status, Pageable pageable);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+        UPDATE classes
+        SET enrolled_count = enrolled_count + 1
+        WHERE id = :id
+          AND status = 'OPEN'
+          AND enrolled_count < capacity
+        """, nativeQuery = true)
+    int tryIncrementEnrolled(@Param("id") Long id);
 }

--- a/src/main/java/com/example/be_a/enrollment/application/ApplyEnrollmentCommand.java
+++ b/src/main/java/com/example/be_a/enrollment/application/ApplyEnrollmentCommand.java
@@ -1,0 +1,7 @@
+package com.example.be_a.enrollment.application;
+
+public record ApplyEnrollmentCommand(
+    Long classId,
+    boolean waitlist
+) {
+}

--- a/src/main/java/com/example/be_a/enrollment/application/EnrollmentApplyService.java
+++ b/src/main/java/com/example/be_a/enrollment/application/EnrollmentApplyService.java
@@ -1,0 +1,99 @@
+package com.example.be_a.enrollment.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import java.util.Locale;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EnrollmentApplyService {
+
+    private static final String ENROLLMENT_UNIQUE_CONSTRAINT = "uk_enrollments_class_user";
+
+    private final ClassRepository classRepository;
+    private final EnrollmentRepository enrollmentRepository;
+
+    public EnrollmentApplyService(
+        ClassRepository classRepository,
+        EnrollmentRepository enrollmentRepository
+    ) {
+        this.classRepository = classRepository;
+        this.enrollmentRepository = enrollmentRepository;
+    }
+
+    @Transactional
+    public EnrollmentEntity apply(CurrentUserInfo user, ApplyEnrollmentCommand command) {
+        Long classId = command.classId();
+        Long userId = user.id();
+
+        validateNotEnrolled(classId, userId);
+
+        int updated = classRepository.tryIncrementEnrolled(classId);
+        if (updated == 1) {
+            return saveEnrollment(EnrollmentEntity.createPending(classId, userId));
+        }
+
+        ClassEntity classEntity = classRepository.findById(classId)
+            .orElseThrow(() -> new ApiException(ErrorCode.CLASS_NOT_FOUND));
+
+        ensureOpen(classEntity);
+
+        if (!command.waitlist()) {
+            throw new ApiException(ErrorCode.CLASS_FULL);
+        }
+
+        return saveEnrollment(EnrollmentEntity.createWaiting(classId, userId));
+    }
+
+    private void ensureOpen(ClassEntity classEntity) {
+        if (classEntity.getStatus() != ClassStatus.OPEN) {
+            throw new ApiException(ErrorCode.CLASS_NOT_OPEN);
+        }
+    }
+
+    private void validateNotEnrolled(Long classId, Long userId) {
+        if (enrollmentRepository.existsByClassIdAndUserId(classId, userId)) {
+            throw new ApiException(ErrorCode.ALREADY_ENROLLED);
+        }
+    }
+
+    private EnrollmentEntity saveEnrollment(EnrollmentEntity enrollment) {
+        try {
+            return enrollmentRepository.saveAndFlush(enrollment);
+        } catch (DataIntegrityViolationException exception) {
+            if (isDuplicateEnrollmentException(exception)) {
+                throw new ApiException(ErrorCode.ALREADY_ENROLLED);
+            }
+            throw exception;
+        }
+    }
+
+    private boolean isDuplicateEnrollmentException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof ConstraintViolationException constraintViolationException
+                && isEnrollmentUniqueConstraint(constraintViolationException.getConstraintName())) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private boolean isEnrollmentUniqueConstraint(String constraintName) {
+        if (constraintName == null) {
+            return false;
+        }
+        return constraintName.toLowerCase(Locale.ROOT)
+            .endsWith(ENROLLMENT_UNIQUE_CONSTRAINT.toLowerCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/com/example/be_a/enrollment/domain/EnrollmentEntity.java
+++ b/src/main/java/com/example/be_a/enrollment/domain/EnrollmentEntity.java
@@ -1,0 +1,66 @@
+package com.example.be_a.enrollment.domain;
+
+import com.example.be_a.global.support.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Getter
+@Entity
+@Table(name = "enrollments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EnrollmentEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "class_id", nullable = false)
+    private Long classId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private EnrollmentStatus status;
+
+    @CreationTimestamp
+    @Column(name = "requested_at", nullable = false, updatable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "confirmed_at")
+    private LocalDateTime confirmedAt;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
+
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
+    private EnrollmentEntity(Long classId, Long userId, EnrollmentStatus status) {
+        this.classId = classId;
+        this.userId = userId;
+        this.status = status;
+    }
+
+    public static EnrollmentEntity createPending(Long classId, Long userId) {
+        return new EnrollmentEntity(classId, userId, EnrollmentStatus.PENDING);
+    }
+
+    public static EnrollmentEntity createWaiting(Long classId, Long userId) {
+        return new EnrollmentEntity(classId, userId, EnrollmentStatus.WAITING);
+    }
+}

--- a/src/main/java/com/example/be_a/enrollment/domain/EnrollmentRepository.java
+++ b/src/main/java/com/example/be_a/enrollment/domain/EnrollmentRepository.java
@@ -1,0 +1,8 @@
+package com.example.be_a.enrollment.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EnrollmentRepository extends JpaRepository<EnrollmentEntity, Long> {
+
+    boolean existsByClassIdAndUserId(Long classId, Long userId);
+}

--- a/src/main/java/com/example/be_a/enrollment/presentation/ApplyEnrollmentRequest.java
+++ b/src/main/java/com/example/be_a/enrollment/presentation/ApplyEnrollmentRequest.java
@@ -1,0 +1,15 @@
+package com.example.be_a.enrollment.presentation;
+
+import com.example.be_a.enrollment.application.ApplyEnrollmentCommand;
+import jakarta.validation.constraints.NotNull;
+
+public record ApplyEnrollmentRequest(
+    @NotNull(message = "classId는 필수입니다.")
+    Long classId,
+    boolean waitlist
+) {
+
+    public ApplyEnrollmentCommand toCommand() {
+        return new ApplyEnrollmentCommand(classId, waitlist);
+    }
+}

--- a/src/main/java/com/example/be_a/enrollment/presentation/EnrollmentController.java
+++ b/src/main/java/com/example/be_a/enrollment/presentation/EnrollmentController.java
@@ -1,0 +1,34 @@
+package com.example.be_a.enrollment.presentation;
+
+import com.example.be_a.enrollment.application.EnrollmentApplyService;
+import com.example.be_a.global.config.CurrentUser;
+import com.example.be_a.user.application.CurrentUserInfo;
+import jakarta.validation.Valid;
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/enrollments")
+public class EnrollmentController {
+
+    private final EnrollmentApplyService enrollmentApplyService;
+
+    public EnrollmentController(EnrollmentApplyService enrollmentApplyService) {
+        this.enrollmentApplyService = enrollmentApplyService;
+    }
+
+    @PostMapping
+    public ResponseEntity<EnrollmentResponse> apply(
+        @CurrentUser CurrentUserInfo user,
+        @Valid @RequestBody ApplyEnrollmentRequest request
+    ) {
+        EnrollmentResponse response = EnrollmentResponse.from(enrollmentApplyService.apply(user, request.toCommand()));
+
+        return ResponseEntity.created(URI.create("/api/enrollments/" + response.id()))
+            .body(response);
+    }
+}

--- a/src/main/java/com/example/be_a/enrollment/presentation/EnrollmentResponse.java
+++ b/src/main/java/com/example/be_a/enrollment/presentation/EnrollmentResponse.java
@@ -1,0 +1,30 @@
+package com.example.be_a.enrollment.presentation;
+
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDateTime;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record EnrollmentResponse(
+    Long id,
+    Long classId,
+    Long userId,
+    EnrollmentStatus status,
+    LocalDateTime requestedAt,
+    LocalDateTime confirmedAt,
+    LocalDateTime cancelledAt
+) {
+
+    public static EnrollmentResponse from(EnrollmentEntity enrollment) {
+        return new EnrollmentResponse(
+            enrollment.getId(),
+            enrollment.getClassId(),
+            enrollment.getUserId(),
+            enrollment.getStatus(),
+            enrollment.getRequestedAt(),
+            enrollment.getConfirmedAt(),
+            enrollment.getCancelledAt()
+        );
+    }
+}

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentApplyConcurrencyIntegrationTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentApplyConcurrencyIntegrationTest.java
@@ -1,0 +1,200 @@
+package com.example.be_a.enrollment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.reset;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.application.ApplyEnrollmentCommand;
+import com.example.be_a.enrollment.application.EnrollmentApplyService;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.domain.UserRole;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class EnrollmentApplyConcurrencyIntegrationTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private EnrollmentApplyService enrollmentApplyService;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @SpyBean
+    private EnrollmentRepository enrollmentRepositorySpy;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private ExecutorService executorService;
+
+    @BeforeEach
+    void setUp() {
+        executorService = Executors.newFixedThreadPool(10);
+        ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
+        for (long userId = 20L; userId < 30L; userId++) {
+            ensureUser(userId, "student" + userId + "@example.com", "Student " + userId, "STUDENT");
+        }
+        enrollmentRepository.deleteAllInBatch();
+        classRepository.deleteAllInBatch();
+    }
+
+    @AfterEach
+    void tearDown() {
+        executorService.shutdownNow();
+        reset(enrollmentRepositorySpy);
+    }
+
+    @Test
+    void 정원_1명_강의에_10명이_동시_신청하면_1명만_PENDING_성공하고_9명은_CLASS_FULL을_반환한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 1, "동시 신청 강의");
+        Queue<String> results = new ConcurrentLinkedQueue<>();
+        CountDownLatch readyLatch = new CountDownLatch(10);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(10);
+
+        for (long userId = 20L; userId < 30L; userId++) {
+            long requestUserId = userId;
+            executorService.submit(() -> {
+                readyLatch.countDown();
+                try {
+                    startLatch.await();
+                    enrollmentApplyService.apply(
+                        new CurrentUserInfo(requestUserId, UserRole.STUDENT),
+                        new ApplyEnrollmentCommand(classEntity.getId(), false)
+                    );
+                    results.add("PENDING");
+                } catch (ApiException exception) {
+                    results.add(exception.getErrorCode().name());
+                } catch (Exception exception) {
+                    results.add("ERROR:" + exception.getClass().getSimpleName());
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        assertThat(readyLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        startLatch.countDown();
+        assertThat(doneLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+        long successCount = results.stream().filter("PENDING"::equals).count();
+        long classFullCount = results.stream().filter("CLASS_FULL"::equals).count();
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        List<EnrollmentEntity> enrollments = enrollmentRepository.findAll();
+
+        assertThat(results).hasSize(10);
+        assertThat(successCount).isEqualTo(1);
+        assertThat(classFullCount).isEqualTo(9);
+        assertThat(results.stream().filter(result -> result.startsWith("ERROR:"))).isEmpty();
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollments).hasSize(1);
+        assertThat(enrollments.get(0).getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+    }
+
+    @Test
+    void 같은_사용자가_동시에_두_번_신청하면_실제_UNIQUE_위반이_ALREADY_ENROLLED로_정규화된다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 10, "중복 신청 경합 강의");
+        Queue<String> results = new ConcurrentLinkedQueue<>();
+        CountDownLatch existsReadyLatch = new CountDownLatch(2);
+        CountDownLatch existsReleaseLatch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            Long classId = invocation.getArgument(0);
+            Long userId = invocation.getArgument(1);
+            if (classEntity.getId().equals(classId) && Long.valueOf(20L).equals(userId)) {
+                existsReadyLatch.countDown();
+                assertThat(existsReleaseLatch.await(5, TimeUnit.SECONDS)).isTrue();
+                return false;
+            }
+            return invocation.callRealMethod();
+        }).when(enrollmentRepositorySpy).existsByClassIdAndUserId(eq(classEntity.getId()), eq(20L));
+
+        Callable<Void> applyTask = () -> {
+            try {
+                enrollmentApplyService.apply(
+                    new CurrentUserInfo(20L, UserRole.STUDENT),
+                    new ApplyEnrollmentCommand(classEntity.getId(), false)
+                );
+                results.add("PENDING");
+            } catch (ApiException exception) {
+                results.add(exception.getErrorCode().name());
+            }
+            return null;
+        };
+
+        var first = executorService.submit(applyTask);
+        var second = executorService.submit(applyTask);
+
+        assertThat(existsReadyLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        existsReleaseLatch.countDown();
+
+        first.get(10, TimeUnit.SECONDS);
+        second.get(10, TimeUnit.SECONDS);
+
+        long successCount = results.stream().filter("PENDING"::equals).count();
+        long duplicateCount = results.stream().filter("ALREADY_ENROLLED"::equals).count();
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        List<EnrollmentEntity> enrollments = enrollmentRepository.findAll();
+
+        assertThat(results).hasSize(2);
+        assertThat(successCount).isEqualTo(1);
+        assertThat(duplicateCount).isEqualTo(1);
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollments).hasSize(1);
+        assertThat(enrollments.get(0).getUserId()).isEqualTo(20L);
+        assertThat(enrollments.get(0).getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+    }
+
+    private void ensureUser(Long id, String email, String name, String role) {
+        jdbcTemplate.update("""
+            INSERT INTO users (id, email, name, role)
+            VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE email = VALUES(email), name = VALUES(name), role = VALUES(role)
+            """, id, email, name, role);
+    }
+
+    private ClassEntity saveOpenClass(Long creatorId, int capacity, String title) {
+        ClassEntity classEntity = classRepository.save(ClassEntity.createDraft(
+            creatorId,
+            title,
+            "설명",
+            30000,
+            capacity,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        ));
+        jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", ClassStatus.OPEN.name(), classEntity.getId());
+        return classRepository.findById(classEntity.getId()).orElseThrow();
+    }
+}

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentApplyIntegrationTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentApplyIntegrationTest.java
@@ -1,0 +1,226 @@
+package com.example.be_a.enrollment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class EnrollmentApplyIntegrationTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
+        ensureUser(20L, "student20@example.com", "Student Twenty", "STUDENT");
+        ensureUser(21L, "student21@example.com", "Student Twenty One", "STUDENT");
+        ensureUser(22L, "student22@example.com", "Student Twenty Two", "STUDENT");
+        enrollmentRepository.deleteAllInBatch();
+        classRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 정원이_남아_있으면_PENDING_상태로_수강_신청할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 1, "신청 가능한 강의");
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), false)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", matchesPattern("/api/enrollments/\\d+")))
+            .andExpect(jsonPath("$.id").isNumber())
+            .andExpect(jsonPath("$.classId").value(classEntity.getId()))
+            .andExpect(jsonPath("$.userId").value(20))
+            .andExpect(jsonPath("$.status").value("PENDING"))
+            .andExpect(jsonPath("$.requestedAt").exists());
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        List<EnrollmentEntity> enrollments = enrollmentRepository.findAll();
+
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollments).hasSize(1);
+        assertThat(enrollments.get(0).getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+    }
+
+    @Test
+    void 이미_신청한_강의면_ALREADY_ENROLLED를_반환한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 2, "중복 신청 강의");
+        apply(classEntity.getId(), 20L, false);
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), false)))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("ALREADY_ENROLLED"));
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollmentRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void DRAFT_강의는_CLASS_NOT_OPEN을_반환한다() throws Exception {
+        ClassEntity classEntity = saveDraftClass(10L, 1, "초안 강의");
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), false)))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_NOT_OPEN"));
+    }
+
+    @Test
+    void CLOSED_강의는_CLASS_NOT_OPEN을_반환한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 1, "마감 강의");
+        updateStatus(classEntity.getId(), ClassStatus.CLOSED);
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), false)))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_NOT_OPEN"));
+    }
+
+    @Test
+    void 정원이_가득_찼고_대기열을_사용하지_않으면_CLASS_FULL을_반환한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 1, "정원 마감 강의");
+        apply(classEntity.getId(), 20L, false);
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "21")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), false)))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_FULL"));
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollmentRepository.findAll()).hasSize(1);
+    }
+
+    @Test
+    void 정원이_가득_찼고_대기열을_사용하면_WAITING으로_저장된다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 1, "대기열 강의");
+        apply(classEntity.getId(), 20L, false);
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "21")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), true)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", matchesPattern("/api/enrollments/\\d+")))
+            .andExpect(jsonPath("$.classId").value(classEntity.getId()))
+            .andExpect(jsonPath("$.userId").value(21))
+            .andExpect(jsonPath("$.status").value("WAITING"))
+            .andExpect(jsonPath("$.requestedAt").exists());
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        List<EnrollmentEntity> enrollments = enrollmentRepository.findAll();
+
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollments).hasSize(2);
+        assertThat(enrollments)
+            .extracting(EnrollmentEntity::getStatus)
+            .containsExactlyInAnyOrder(EnrollmentStatus.PENDING, EnrollmentStatus.WAITING);
+    }
+
+    @Test
+    void classId가_없으면_VALIDATION_ERROR와_fieldErrors를_반환한다() throws Exception {
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "waitlist": true
+                    }
+                    """))
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+            .andExpect(jsonPath("$.fieldErrors[0].field").value("classId"));
+    }
+
+    private void apply(Long classId, Long userId, boolean waitlist) throws Exception {
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", String.valueOf(userId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classId, waitlist)))
+            .andExpect(status().isCreated());
+    }
+
+    private String requestBody(Long classId, boolean waitlist) {
+        return """
+            {
+              "classId": %d,
+              "waitlist": %s
+            }
+            """.formatted(classId, waitlist);
+    }
+
+    private void ensureUser(Long id, String email, String name, String role) {
+        jdbcTemplate.update("""
+            INSERT INTO users (id, email, name, role)
+            VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE email = VALUES(email), name = VALUES(name), role = VALUES(role)
+            """, id, email, name, role);
+    }
+
+    private ClassEntity saveDraftClass(Long creatorId, int capacity, String title) {
+        return classRepository.save(ClassEntity.createDraft(
+            creatorId,
+            title,
+            "설명",
+            30000,
+            capacity,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        ));
+    }
+
+    private ClassEntity saveOpenClass(Long creatorId, int capacity, String title) {
+        ClassEntity classEntity = saveDraftClass(creatorId, capacity, title);
+        updateStatus(classEntity.getId(), ClassStatus.OPEN);
+        return classRepository.findById(classEntity.getId()).orElseThrow();
+    }
+
+    private void updateStatus(Long classId, ClassStatus status) {
+        jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", status.name(), classId);
+    }
+}

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentApplyServiceTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentApplyServiceTest.java
@@ -1,0 +1,185 @@
+package com.example.be_a.enrollment;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.application.ApplyEnrollmentCommand;
+import com.example.be_a.enrollment.application.EnrollmentApplyService;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.domain.UserRole;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.hibernate.exception.ConstraintViolationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentApplyServiceTest {
+
+    @Mock
+    private ClassRepository classRepository;
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @InjectMocks
+    private EnrollmentApplyService enrollmentApplyService;
+
+    @Test
+    void 저장_중_UNIQUE_예외가_나면_ALREADY_ENROLLED로_변환한다() {
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(classRepository.tryIncrementEnrolled(1L)).thenReturn(1);
+        when(enrollmentRepository.saveAndFlush(any()))
+            .thenThrow(new DataIntegrityViolationException(
+                "duplicate key",
+                new ConstraintViolationException("duplicate key", null, "UK_ENROLLMENTS_CLASS_USER")
+            ));
+
+        assertThatThrownBy(() -> enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, false)))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.ALREADY_ENROLLED);
+    }
+
+    @Test
+    void UNIQUE가_아닌_무결성_예외는_그대로_전파한다() {
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(classRepository.tryIncrementEnrolled(1L)).thenReturn(1);
+        when(enrollmentRepository.saveAndFlush(any()))
+            .thenThrow(new DataIntegrityViolationException(
+                "fk violation",
+                new ConstraintViolationException("fk violation", null, "fk_enrollments_class")
+            ));
+
+        assertThatThrownBy(() -> enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, false)))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void 중복_신청이면_정원_증가를_시도하지_않고_ALREADY_ENROLLED를_반환한다() {
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(true);
+
+        assertThatThrownBy(() -> enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, false)))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.ALREADY_ENROLLED);
+
+        verify(classRepository, never()).tryIncrementEnrolled(any());
+        verify(enrollmentRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void 강의가_없으면_CLASS_NOT_FOUND를_반환한다() {
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(classRepository.tryIncrementEnrolled(1L)).thenReturn(0);
+        when(classRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, false)))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CLASS_NOT_FOUND);
+
+        verify(enrollmentRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void 정원_증가_실패_후_강의가_CLOSED면_CLASS_NOT_OPEN을_반환한다() {
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(classRepository.tryIncrementEnrolled(1L)).thenReturn(0);
+        when(classRepository.findById(1L)).thenReturn(Optional.of(classWithStatus(10L, "마감 강의", ClassStatus.CLOSED)));
+
+        assertThatThrownBy(() -> enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, true)))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CLASS_NOT_OPEN);
+
+        verify(enrollmentRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void 정원_증가_실패_후_WAITLIST를_사용하지_않으면_CLASS_FULL을_반환한다() {
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(classRepository.tryIncrementEnrolled(1L)).thenReturn(0);
+        when(classRepository.findById(1L)).thenReturn(Optional.of(classWithStatus(10L, "만석 강의", ClassStatus.OPEN)));
+
+        assertThatThrownBy(() -> enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, false)))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CLASS_FULL);
+
+        verify(enrollmentRepository, never()).saveAndFlush(any());
+    }
+
+    @Test
+    void 정원_증가_실패_후_WAITLIST를_사용하면_WAITING으로_저장한다() {
+        CurrentUserInfo user = studentUser(20L);
+        ArgumentCaptor<EnrollmentEntity> enrollmentCaptor = ArgumentCaptor.forClass(EnrollmentEntity.class);
+
+        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(classRepository.tryIncrementEnrolled(1L)).thenReturn(0);
+        when(classRepository.findById(1L)).thenReturn(Optional.of(classWithStatus(10L, "대기열 강의", ClassStatus.OPEN)));
+        when(enrollmentRepository.saveAndFlush(any()))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, true));
+
+        verify(enrollmentRepository, times(1)).saveAndFlush(enrollmentCaptor.capture());
+
+        EnrollmentEntity savedEnrollment = enrollmentCaptor.getValue();
+        org.assertj.core.api.Assertions.assertThat(savedEnrollment.getClassId()).isEqualTo(1L);
+        org.assertj.core.api.Assertions.assertThat(savedEnrollment.getUserId()).isEqualTo(20L);
+        org.assertj.core.api.Assertions.assertThat(savedEnrollment.getStatus()).isEqualTo(EnrollmentStatus.WAITING);
+    }
+
+    private CurrentUserInfo studentUser(Long userId) {
+        return new CurrentUserInfo(userId, UserRole.STUDENT);
+    }
+
+    private ClassEntity classWithStatus(Long creatorId, String title, ClassStatus status) {
+        ClassEntity classEntity = ClassEntity.createDraft(
+            creatorId,
+            title,
+            "설명",
+            30000,
+            30,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        );
+        if (status == ClassStatus.OPEN || status == ClassStatus.CLOSED) {
+            classEntity.changeStatus(ClassStatus.OPEN);
+        }
+        if (status == ClassStatus.CLOSED) {
+            classEntity.changeStatus(ClassStatus.CLOSED);
+        }
+        return classEntity;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #15 

## 요약
  - 수강 신청 API 추가
  - 정원 초과 방지와 중복 신청 방지 로직 반영
  - 단위, 통합, 동시성 테스트 추가

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
