### PR TITLE
수강 신청 결제 확정 기능 구현

### DIFF
--- a/src/main/java/com/example/be_a/enrollment/application/EnrollmentConfirmService.java
+++ b/src/main/java/com/example/be_a/enrollment/application/EnrollmentConfirmService.java
@@ -1,0 +1,60 @@
+package com.example.be_a.enrollment.application;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.application.UserAuthorizationService;
+import java.time.LocalDateTime;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EnrollmentConfirmService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final ClassRepository classRepository;
+    private final UserAuthorizationService userAuthorizationService;
+
+    public EnrollmentConfirmService(
+        EnrollmentRepository enrollmentRepository,
+        ClassRepository classRepository,
+        UserAuthorizationService userAuthorizationService
+    ) {
+        this.enrollmentRepository = enrollmentRepository;
+        this.classRepository = classRepository;
+        this.userAuthorizationService = userAuthorizationService;
+    }
+
+    @Transactional
+    public EnrollmentEntity confirm(Long enrollmentId, CurrentUserInfo user) {
+        EnrollmentEntity enrollment = loadOwnedEnrollment(enrollmentId, user);
+        ensureClassConfirmable(loadClass(enrollment.getClassId()));
+
+        enrollment.confirm(LocalDateTime.now());
+        return enrollment;
+    }
+
+    private EnrollmentEntity loadOwnedEnrollment(Long enrollmentId, CurrentUserInfo user) {
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId)
+            .orElseThrow(() -> new ApiException(ErrorCode.ENROLLMENT_NOT_FOUND));
+
+        userAuthorizationService.requireOwner(user, enrollment.getUserId());
+        return enrollment;
+    }
+
+    private ClassEntity loadClass(Long classId) {
+        return classRepository.findById(classId)
+            .orElseThrow(() -> new ApiException(ErrorCode.CLASS_NOT_FOUND));
+    }
+
+    private void ensureClassConfirmable(ClassEntity classEntity) {
+        if (classEntity.getStatus() != ClassStatus.OPEN) {
+            throw new ApiException(ErrorCode.CLASS_NOT_OPEN);
+        }
+    }
+}

--- a/src/main/java/com/example/be_a/enrollment/domain/EnrollmentEntity.java
+++ b/src/main/java/com/example/be_a/enrollment/domain/EnrollmentEntity.java
@@ -1,5 +1,7 @@
 package com.example.be_a.enrollment.domain;
 
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
 import com.example.be_a.global.support.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -62,5 +64,13 @@ public class EnrollmentEntity extends BaseEntity {
 
     public static EnrollmentEntity createWaiting(Long classId, Long userId) {
         return new EnrollmentEntity(classId, userId, EnrollmentStatus.WAITING);
+    }
+
+    public void confirm(LocalDateTime confirmedAt) {
+        if (status != EnrollmentStatus.PENDING) {
+            throw new ApiException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+        this.status = EnrollmentStatus.CONFIRMED;
+        this.confirmedAt = confirmedAt;
     }
 }

--- a/src/main/java/com/example/be_a/enrollment/presentation/EnrollmentController.java
+++ b/src/main/java/com/example/be_a/enrollment/presentation/EnrollmentController.java
@@ -1,12 +1,14 @@
 package com.example.be_a.enrollment.presentation;
 
 import com.example.be_a.enrollment.application.EnrollmentApplyService;
+import com.example.be_a.enrollment.application.EnrollmentConfirmService;
 import com.example.be_a.global.config.CurrentUser;
 import com.example.be_a.user.application.CurrentUserInfo;
 import jakarta.validation.Valid;
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -16,9 +18,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class EnrollmentController {
 
     private final EnrollmentApplyService enrollmentApplyService;
+    private final EnrollmentConfirmService enrollmentConfirmService;
 
-    public EnrollmentController(EnrollmentApplyService enrollmentApplyService) {
+    public EnrollmentController(
+        EnrollmentApplyService enrollmentApplyService,
+        EnrollmentConfirmService enrollmentConfirmService
+    ) {
         this.enrollmentApplyService = enrollmentApplyService;
+        this.enrollmentConfirmService = enrollmentConfirmService;
     }
 
     @PostMapping
@@ -30,5 +37,13 @@ public class EnrollmentController {
 
         return ResponseEntity.created(URI.create("/api/enrollments/" + response.id()))
             .body(response);
+    }
+
+    @PostMapping("/{enrollmentId}/confirm")
+    public EnrollmentResponse confirm(
+        @PathVariable Long enrollmentId,
+        @CurrentUser CurrentUserInfo user
+    ) {
+        return EnrollmentResponse.from(enrollmentConfirmService.confirm(enrollmentId, user));
     }
 }

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentConfirmIntegrationTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentConfirmIntegrationTest.java
@@ -1,0 +1,184 @@
+package com.example.be_a.enrollment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class EnrollmentConfirmIntegrationTest extends MySqlTestContainerSupport {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
+        ensureUser(20L, "student20@example.com", "Student Twenty", "STUDENT");
+        ensureUser(21L, "student21@example.com", "Student Twenty One", "STUDENT");
+        enrollmentRepository.deleteAllInBatch();
+        classRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void PENDING_수강_신청은_결제_확정할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.PENDING);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/confirm", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(enrollmentId))
+            .andExpect(jsonPath("$.classId").value(classEntity.getId()))
+            .andExpect(jsonPath("$.userId").value(20))
+            .andExpect(jsonPath("$.status").value("CONFIRMED"))
+            .andExpect(jsonPath("$.confirmedAt").exists());
+
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId).orElseThrow();
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+        assertThat(enrollment.getConfirmedAt()).isNotNull();
+    }
+
+    @Test
+    void 존재하지_않는_수강_신청은_ENROLLMENT_NOT_FOUND를_반환한다() throws Exception {
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/confirm", 99999L)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("ENROLLMENT_NOT_FOUND"));
+    }
+
+    @Test
+    void WAITING_수강_신청은_결제_확정할_수_없다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.WAITING);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/confirm", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void CANCELLED_수강_신청은_결제_확정할_수_없다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.CANCELLED);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/confirm", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void 다른_사용자의_수강_신청은_결제_확정할_수_없다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.PENDING);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/confirm", enrollmentId)
+                .header("X-User-Id", "21"))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    void CLOSED_강의의_수강_신청은_결제_확정할_수_없다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.PENDING);
+        updateClassStatus(classEntity.getId(), ClassStatus.CLOSED);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/confirm", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_NOT_OPEN"));
+    }
+
+    @Test
+    void DRAFT_강의의_수강_신청은_결제_확정할_수_없다() throws Exception {
+        ClassEntity classEntity = saveDraftClass();
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.PENDING);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/confirm", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CLASS_NOT_OPEN"));
+    }
+
+    private void ensureUser(Long id, String email, String name, String role) {
+        jdbcTemplate.update("""
+            INSERT INTO users (id, email, name, role)
+            VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE email = VALUES(email), name = VALUES(name), role = VALUES(role)
+            """, id, email, name, role);
+    }
+
+    private ClassEntity saveOpenClass() {
+        ClassEntity classEntity = saveDraftClass();
+        updateClassStatus(classEntity.getId(), ClassStatus.OPEN);
+        return classRepository.findById(classEntity.getId()).orElseThrow();
+    }
+
+    private ClassEntity saveDraftClass() {
+        return classRepository.save(ClassEntity.createDraft(
+            10L,
+            "결제 확정 강의",
+            "설명",
+            30000,
+            30,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        ));
+    }
+
+    private void updateClassStatus(Long classId, ClassStatus status) {
+        jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", status.name(), classId);
+    }
+
+    private Long insertEnrollment(Long classId, Long userId, EnrollmentStatus status) {
+        jdbcTemplate.update("""
+            INSERT INTO enrollments (class_id, user_id, status, requested_at, cancelled_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            classId,
+            userId,
+            status.name(),
+            LocalDateTime.of(2026, 4, 23, 10, 0),
+            status == EnrollmentStatus.CANCELLED ? LocalDateTime.of(2026, 4, 23, 11, 0) : null
+        );
+
+        return jdbcTemplate.queryForObject(
+            "SELECT id FROM enrollments WHERE class_id = ? AND user_id = ?",
+            Long.class,
+            classId,
+            userId
+        );
+    }
+}

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentConfirmServiceTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentConfirmServiceTest.java
@@ -1,0 +1,169 @@
+package com.example.be_a.enrollment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.application.EnrollmentConfirmService;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.application.UserAuthorizationService;
+import com.example.be_a.user.domain.UserRole;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentConfirmServiceTest {
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private ClassRepository classRepository;
+
+    @Mock
+    private UserAuthorizationService userAuthorizationService;
+
+    @InjectMocks
+    private EnrollmentConfirmService enrollmentConfirmService;
+
+    @Test
+    void PENDING_상태면_CONFIRMED로_변경한다() {
+        EnrollmentEntity enrollment = enrollmentWithStatus(EnrollmentStatus.PENDING);
+        CurrentUserInfo user = new CurrentUserInfo(20L, UserRole.STUDENT);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        when(classRepository.findById(10L)).thenReturn(Optional.of(openClass()));
+
+        EnrollmentEntity confirmed = enrollmentConfirmService.confirm(1L, user);
+
+        assertThat(confirmed.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+        assertThat(confirmed.getConfirmedAt()).isNotNull();
+    }
+
+    @Test
+    void 수강_신청이_없으면_ENROLLMENT_NOT_FOUND를_반환한다() {
+        CurrentUserInfo user = new CurrentUserInfo(20L, UserRole.STUDENT);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> enrollmentConfirmService.confirm(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.ENROLLMENT_NOT_FOUND);
+    }
+
+    @Test
+    void 다른_사용자의_수강_신청이면_FORBIDDEN을_반환한다() {
+        EnrollmentEntity enrollment = enrollmentWithStatus(EnrollmentStatus.PENDING);
+        CurrentUserInfo user = new CurrentUserInfo(21L, UserRole.STUDENT);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        doThrow(new ApiException(ErrorCode.FORBIDDEN))
+            .when(userAuthorizationService)
+            .requireOwner(user, 20L);
+
+        assertThatThrownBy(() -> enrollmentConfirmService.confirm(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void WAITING_상태면_INVALID_STATE_TRANSITION을_반환한다() {
+        EnrollmentEntity enrollment = enrollmentWithStatus(EnrollmentStatus.WAITING);
+        CurrentUserInfo user = new CurrentUserInfo(20L, UserRole.STUDENT);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        when(classRepository.findById(10L)).thenReturn(Optional.of(openClass()));
+
+        assertThatThrownBy(() -> enrollmentConfirmService.confirm(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION);
+    }
+
+    @Test
+    void CLOSED_강의면_CLASS_NOT_OPEN을_반환한다() {
+        EnrollmentEntity enrollment = enrollmentWithStatus(EnrollmentStatus.PENDING);
+        CurrentUserInfo user = new CurrentUserInfo(20L, UserRole.STUDENT);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        when(classRepository.findById(10L)).thenReturn(Optional.of(closedClass()));
+
+        assertThatThrownBy(() -> enrollmentConfirmService.confirm(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CLASS_NOT_OPEN);
+    }
+
+    @Test
+    void DRAFT_강의면_CLASS_NOT_OPEN을_반환한다() {
+        EnrollmentEntity enrollment = enrollmentWithStatus(EnrollmentStatus.PENDING);
+        CurrentUserInfo user = new CurrentUserInfo(20L, UserRole.STUDENT);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        when(classRepository.findById(10L)).thenReturn(Optional.of(draftClass()));
+
+        assertThatThrownBy(() -> enrollmentConfirmService.confirm(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CLASS_NOT_OPEN);
+    }
+
+    private EnrollmentEntity enrollmentWithStatus(EnrollmentStatus status) {
+        EnrollmentEntity enrollment = EnrollmentEntity.createPending(10L, 20L);
+        ReflectionTestUtils.setField(enrollment, "id", 1L);
+        ReflectionTestUtils.setField(enrollment, "status", status);
+        return enrollment;
+    }
+
+    private ClassEntity openClass() {
+        ClassEntity classEntity = ClassEntity.createDraft(
+            10L,
+            "확정 대상 강의",
+            "설명",
+            30000,
+            30,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        );
+        classEntity.changeStatus(ClassStatus.OPEN);
+        ReflectionTestUtils.setField(classEntity, "id", 10L);
+        return classEntity;
+    }
+
+    private ClassEntity closedClass() {
+        ClassEntity classEntity = openClass();
+        classEntity.changeStatus(ClassStatus.CLOSED);
+        return classEntity;
+    }
+
+    private ClassEntity draftClass() {
+        ClassEntity classEntity = ClassEntity.createDraft(
+            10L,
+            "확정 대상 강의",
+            "설명",
+            30000,
+            30,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        );
+        ReflectionTestUtils.setField(classEntity, "id", 10L);
+        return classEntity;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #17 

## 요약
  - 수강 신청 결제 확정 API 추가
  - 결제 확정 상태 전이와 강의 상태 검증 반영
  - 단위, 통합 테스트 추가

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
