### PR TITLE
수강 취소 기능 구현

### DIFF
--- a/src/main/java/com/example/be_a/class_/domain/ClassRepository.java
+++ b/src/main/java/com/example/be_a/class_/domain/ClassRepository.java
@@ -20,4 +20,13 @@ public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
           AND enrolled_count < capacity
         """, nativeQuery = true)
     int tryIncrementEnrolled(@Param("id") Long id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+        UPDATE classes
+        SET enrolled_count = enrolled_count - 1
+        WHERE id = :id
+          AND enrolled_count > 0
+        """, nativeQuery = true)
+    int tryDecrementEnrolled(@Param("id") Long id);
 }

--- a/src/main/java/com/example/be_a/enrollment/application/EnrollmentCancelService.java
+++ b/src/main/java/com/example/be_a/enrollment/application/EnrollmentCancelService.java
@@ -1,0 +1,74 @@
+package com.example.be_a.enrollment.application;
+
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.application.UserAuthorizationService;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class EnrollmentCancelService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final ClassRepository classRepository;
+    private final UserAuthorizationService userAuthorizationService;
+    private final Clock clock;
+
+    public EnrollmentCancelService(
+        EnrollmentRepository enrollmentRepository,
+        ClassRepository classRepository,
+        UserAuthorizationService userAuthorizationService,
+        Clock clock
+    ) {
+        this.enrollmentRepository = enrollmentRepository;
+        this.classRepository = classRepository;
+        this.userAuthorizationService = userAuthorizationService;
+        this.clock = clock;
+    }
+
+    @Transactional
+    public EnrollmentEntity cancel(Long enrollmentId, CurrentUserInfo user) {
+        EnrollmentEntity enrollment = loadOwnedEnrollment(enrollmentId, user);
+        EnrollmentStatus previousStatus = enrollment.getStatus();
+
+        enrollment.cancel(LocalDateTime.now(clock));
+        saveEnrollment(enrollment);
+
+        if (previousStatus == EnrollmentStatus.WAITING) {
+            return enrollment;
+        }
+
+        restoreCapacity(enrollment.getClassId());
+        return enrollment;
+    }
+
+    private EnrollmentEntity loadOwnedEnrollment(Long enrollmentId, CurrentUserInfo user) {
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId)
+            .orElseThrow(() -> new ApiException(ErrorCode.ENROLLMENT_NOT_FOUND));
+
+        userAuthorizationService.requireOwner(user, enrollment.getUserId());
+        return enrollment;
+    }
+
+    private void saveEnrollment(EnrollmentEntity enrollment) {
+        try {
+            enrollmentRepository.saveAndFlush(enrollment);
+        } catch (OptimisticLockingFailureException exception) {
+            throw new ApiException(ErrorCode.CONFLICT_RETRY);
+        }
+    }
+
+    private void restoreCapacity(Long classId) {
+        if (classRepository.tryDecrementEnrolled(classId) == 0) {
+            throw new IllegalStateException("수강 인원 복구에 실패했습니다. classId=" + classId);
+        }
+    }
+}

--- a/src/main/java/com/example/be_a/enrollment/domain/EnrollmentEntity.java
+++ b/src/main/java/com/example/be_a/enrollment/domain/EnrollmentEntity.java
@@ -73,4 +73,24 @@ public class EnrollmentEntity extends BaseEntity {
         this.status = EnrollmentStatus.CONFIRMED;
         this.confirmedAt = confirmedAt;
     }
+
+    public void cancel(LocalDateTime cancelledAt) {
+        if (status == EnrollmentStatus.CANCELLED) {
+            throw new ApiException(ErrorCode.INVALID_STATE_TRANSITION);
+        }
+
+        if (status == EnrollmentStatus.CONFIRMED && isCancelPeriodExpired(cancelledAt)) {
+            throw new ApiException(ErrorCode.CANCEL_PERIOD_EXPIRED);
+        }
+
+        this.status = EnrollmentStatus.CANCELLED;
+        this.cancelledAt = cancelledAt;
+    }
+
+    private boolean isCancelPeriodExpired(LocalDateTime cancelledAt) {
+        if (confirmedAt == null) {
+            throw new IllegalStateException("결제 확정 시각이 없습니다. enrollmentId=" + id);
+        }
+        return cancelledAt.isAfter(confirmedAt.plusDays(7));
+    }
 }

--- a/src/main/java/com/example/be_a/enrollment/presentation/EnrollmentController.java
+++ b/src/main/java/com/example/be_a/enrollment/presentation/EnrollmentController.java
@@ -1,6 +1,7 @@
 package com.example.be_a.enrollment.presentation;
 
 import com.example.be_a.enrollment.application.EnrollmentApplyService;
+import com.example.be_a.enrollment.application.EnrollmentCancelService;
 import com.example.be_a.enrollment.application.EnrollmentConfirmService;
 import com.example.be_a.global.config.CurrentUser;
 import com.example.be_a.user.application.CurrentUserInfo;
@@ -19,13 +20,16 @@ public class EnrollmentController {
 
     private final EnrollmentApplyService enrollmentApplyService;
     private final EnrollmentConfirmService enrollmentConfirmService;
+    private final EnrollmentCancelService enrollmentCancelService;
 
     public EnrollmentController(
         EnrollmentApplyService enrollmentApplyService,
-        EnrollmentConfirmService enrollmentConfirmService
+        EnrollmentConfirmService enrollmentConfirmService,
+        EnrollmentCancelService enrollmentCancelService
     ) {
         this.enrollmentApplyService = enrollmentApplyService;
         this.enrollmentConfirmService = enrollmentConfirmService;
+        this.enrollmentCancelService = enrollmentCancelService;
     }
 
     @PostMapping
@@ -45,5 +49,13 @@ public class EnrollmentController {
         @CurrentUser CurrentUserInfo user
     ) {
         return EnrollmentResponse.from(enrollmentConfirmService.confirm(enrollmentId, user));
+    }
+
+    @PostMapping("/{enrollmentId}/cancel")
+    public EnrollmentResponse cancel(
+        @PathVariable Long enrollmentId,
+        @CurrentUser CurrentUserInfo user
+    ) {
+        return EnrollmentResponse.from(enrollmentCancelService.cancel(enrollmentId, user));
     }
 }

--- a/src/main/java/com/example/be_a/global/config/ClockConfig.java
+++ b/src/main/java/com/example/be_a/global/config/ClockConfig.java
@@ -1,0 +1,17 @@
+package com.example.be_a.global.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ClockConfig {
+
+    private static final ZoneId APP_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public Clock systemClock() {
+        return Clock.system(APP_ZONE);
+    }
+}

--- a/src/main/resources/db/migration/V2__add_enrollment_timestamp_constraints.sql
+++ b/src/main/resources/db/migration/V2__add_enrollment_timestamp_constraints.sql
@@ -1,0 +1,5 @@
+ALTER TABLE enrollments
+    ADD CONSTRAINT chk_enrollments_confirmed_at
+        CHECK (status <> 'CONFIRMED' OR confirmed_at IS NOT NULL),
+    ADD CONSTRAINT chk_enrollments_cancelled_at
+        CHECK (status <> 'CANCELLED' OR cancelled_at IS NOT NULL);

--- a/src/test/java/com/example/be_a/FlywayMigrationIntegrationTest.java
+++ b/src/test/java/com/example/be_a/FlywayMigrationIntegrationTest.java
@@ -28,8 +28,23 @@ class FlywayMigrationIntegrationTest extends MySqlTestContainerSupport {
             Integer.class
         );
         Integer userCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM users", Integer.class);
+        Integer enrollmentCheckConstraints = jdbcTemplate.queryForObject(
+            """
+                SELECT COUNT(*)
+                FROM information_schema.table_constraints
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'enrollments'
+                  AND constraint_type = 'CHECK'
+                  AND constraint_name IN (
+                    'chk_enrollments_confirmed_at',
+                    'chk_enrollments_cancelled_at'
+                  )
+                """,
+            Integer.class
+        );
 
         assertThat(managedTables).isEqualTo(4);
         assertThat(userCount).isEqualTo(3);
+        assertThat(enrollmentCheckConstraints).isEqualTo(2);
     }
 }

--- a/src/test/java/com/example/be_a/class_/ClassDeleteIntegrationTest.java
+++ b/src/test/java/com/example/be_a/class_/ClassDeleteIntegrationTest.java
@@ -9,6 +9,7 @@ import com.example.be_a.class_.domain.ClassEntity;
 import com.example.be_a.class_.domain.ClassRepository;
 import com.example.be_a.class_.domain.ClassStatus;
 import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import java.time.LocalDateTime;
 import com.example.be_a.support.MySqlTestContainerSupport;
 import java.time.LocalDate;
 import org.junit.jupiter.api.BeforeEach;
@@ -141,8 +142,14 @@ class ClassDeleteIntegrationTest extends MySqlTestContainerSupport {
 
     private void insertEnrollment(Long classId, Long userId, EnrollmentStatus status) {
         jdbcTemplate.update("""
-            INSERT INTO enrollments (class_id, user_id, status)
-            VALUES (?, ?, ?)
-            """, classId, userId, status.name());
+            INSERT INTO enrollments (class_id, user_id, status, confirmed_at, cancelled_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            classId,
+            userId,
+            status.name(),
+            status == EnrollmentStatus.CONFIRMED ? LocalDateTime.of(2026, 4, 23, 10, 0) : null,
+            status == EnrollmentStatus.CANCELLED ? LocalDateTime.of(2026, 4, 23, 11, 0) : null
+        );
     }
 }

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentCancelIntegrationTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentCancelIntegrationTest.java
@@ -1,0 +1,308 @@
+package com.example.be_a.enrollment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.be_a.class_.domain.ClassEntity;
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.class_.domain.ClassStatus;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.example.be_a.support.MySqlTestContainerSupport;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import(EnrollmentCancelIntegrationTest.FixedClockConfig.class)
+class EnrollmentCancelIntegrationTest extends MySqlTestContainerSupport {
+
+    private static final ZoneId TEST_ZONE = ZoneId.of("Asia/Seoul");
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 4, 23, 10, 0);
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClassRepository classRepository;
+
+    @Autowired
+    private EnrollmentRepository enrollmentRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
+        ensureUser(20L, "student20@example.com", "Student Twenty", "STUDENT");
+        ensureUser(21L, "student21@example.com", "Student Twenty One", "STUDENT");
+        enrollmentRepository.deleteAllInBatch();
+        classRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void WAITING_수강_신청은_정원_변화_없이_취소할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.WAITING, null, null);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(enrollmentId))
+            .andExpect(jsonPath("$.status").value("CANCELLED"))
+            .andExpect(jsonPath("$.cancelledAt").exists());
+
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(enrollment.getCancelledAt()).isNotNull();
+        assertThat(savedClass.getEnrolledCount()).isZero();
+    }
+
+    @Test
+    void PENDING_수강_신청은_정원을_복구하며_취소할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.PENDING, null, null);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(enrollmentId))
+            .andExpect(jsonPath("$.status").value("CANCELLED"))
+            .andExpect(jsonPath("$.cancelledAt").exists());
+
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(savedClass.getEnrolledCount()).isZero();
+    }
+
+    @Test
+    void CONFIRMED_상태고_7일_이내면_취소할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long enrollmentId = insertEnrollment(
+            classEntity.getId(),
+            20L,
+            EnrollmentStatus.CONFIRMED,
+            FIXED_NOW.minusDays(6),
+            null
+        );
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(enrollmentId))
+            .andExpect(jsonPath("$.status").value("CANCELLED"))
+            .andExpect(jsonPath("$.cancelledAt").exists());
+
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(savedClass.getEnrolledCount()).isZero();
+    }
+
+    @Test
+    void CONFIRMED_상태고_정확히_7일째면_취소할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long enrollmentId = insertEnrollment(
+            classEntity.getId(),
+            20L,
+            EnrollmentStatus.CONFIRMED,
+            FIXED_NOW.minusDays(7),
+            null
+        );
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(enrollmentId))
+            .andExpect(jsonPath("$.status").value("CANCELLED"))
+            .andExpect(jsonPath("$.cancelledAt").exists());
+
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(savedClass.getEnrolledCount()).isZero();
+    }
+
+    @Test
+    void CONFIRMED_상태고_7일이_지나면_CANCEL_PERIOD_EXPIRED를_반환한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long enrollmentId = insertEnrollment(
+            classEntity.getId(),
+            20L,
+            EnrollmentStatus.CONFIRMED,
+            FIXED_NOW.minusDays(8),
+            null
+        );
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("CANCEL_PERIOD_EXPIRED"));
+
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CONFIRMED);
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 이미_CANCELLED_상태면_INVALID_STATE_TRANSITION을_반환한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        Long enrollmentId = insertEnrollment(
+            classEntity.getId(),
+            20L,
+            EnrollmentStatus.CANCELLED,
+            null,
+            FIXED_NOW.minusDays(1)
+        );
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isConflict())
+            .andExpect(jsonPath("$.code").value("INVALID_STATE_TRANSITION"));
+    }
+
+    @Test
+    void CLOSED_강의의_CONFIRMED_수강도_취소할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long enrollmentId = insertEnrollment(
+            classEntity.getId(),
+            20L,
+            EnrollmentStatus.CONFIRMED,
+            FIXED_NOW.minusDays(3),
+            null
+        );
+        updateStatus(classEntity.getId(), ClassStatus.CLOSED);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(enrollmentId))
+            .andExpect(jsonPath("$.status").value("CANCELLED"))
+            .andExpect(jsonPath("$.cancelledAt").exists());
+
+        EnrollmentEntity enrollment = enrollmentRepository.findById(enrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(savedClass.getEnrolledCount()).isZero();
+    }
+
+    @Test
+    void 다른_사용자의_수강_신청은_취소할_수_없다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long enrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.PENDING, null, null);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", "21"))
+            .andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.code").value("FORBIDDEN"));
+    }
+
+    @Test
+    void 존재하지_않는_수강_신청은_ENROLLMENT_NOT_FOUND를_반환한다() throws Exception {
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", 99999L)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.code").value("ENROLLMENT_NOT_FOUND"));
+    }
+
+    private void ensureUser(Long id, String email, String name, String role) {
+        jdbcTemplate.update("""
+            INSERT INTO users (id, email, name, role)
+            VALUES (?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE email = VALUES(email), name = VALUES(name), role = VALUES(role)
+            """, id, email, name, role);
+    }
+
+    private ClassEntity saveOpenClass() {
+        ClassEntity classEntity = classRepository.save(ClassEntity.createDraft(
+            10L,
+            "수강 취소 강의",
+            "설명",
+            30000,
+            30,
+            LocalDate.of(2026, 5, 1),
+            LocalDate.of(2026, 5, 31)
+        ));
+        updateStatus(classEntity.getId(), ClassStatus.OPEN);
+        return classRepository.findById(classEntity.getId()).orElseThrow();
+    }
+
+    private void updateStatus(Long classId, ClassStatus status) {
+        jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", status.name(), classId);
+    }
+
+    private void updateEnrolledCount(Long classId, int enrolledCount) {
+        jdbcTemplate.update("UPDATE classes SET enrolled_count = ? WHERE id = ?", enrolledCount, classId);
+    }
+
+    private Long insertEnrollment(
+        Long classId,
+        Long userId,
+        EnrollmentStatus status,
+        LocalDateTime confirmedAt,
+        LocalDateTime cancelledAt
+    ) {
+        jdbcTemplate.update("""
+            INSERT INTO enrollments (class_id, user_id, status, requested_at, confirmed_at, cancelled_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            classId,
+            userId,
+            status.name(),
+            FIXED_NOW.minusDays(3),
+            confirmedAt,
+            cancelledAt
+        );
+
+        return jdbcTemplate.queryForObject(
+            "SELECT id FROM enrollments WHERE class_id = ? AND user_id = ?",
+            Long.class,
+            classId,
+            userId
+        );
+    }
+
+    @TestConfiguration
+    static class FixedClockConfig {
+
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(FIXED_NOW.atZone(TEST_ZONE).toInstant(), TEST_ZONE);
+        }
+    }
+}

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentCancelServiceTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentCancelServiceTest.java
@@ -1,0 +1,224 @@
+package com.example.be_a.enrollment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.example.be_a.class_.domain.ClassRepository;
+import com.example.be_a.enrollment.application.EnrollmentCancelService;
+import com.example.be_a.enrollment.domain.EnrollmentEntity;
+import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
+import com.example.be_a.global.error.ApiException;
+import com.example.be_a.global.error.ErrorCode;
+import com.example.be_a.user.application.CurrentUserInfo;
+import com.example.be_a.user.application.UserAuthorizationService;
+import com.example.be_a.user.domain.UserRole;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EnrollmentCancelServiceTest {
+
+    private static final ZoneId TEST_ZONE = ZoneId.of("Asia/Seoul");
+    private static final LocalDateTime FIXED_NOW = LocalDateTime.of(2026, 4, 23, 10, 0);
+
+    @Mock
+    private EnrollmentRepository enrollmentRepository;
+
+    @Mock
+    private ClassRepository classRepository;
+
+    @Mock
+    private UserAuthorizationService userAuthorizationService;
+
+    private EnrollmentCancelService enrollmentCancelService;
+
+    @BeforeEach
+    void setUp() {
+        Clock fixedClock = Clock.fixed(FIXED_NOW.atZone(TEST_ZONE).toInstant(), TEST_ZONE);
+        enrollmentCancelService = new EnrollmentCancelService(
+            enrollmentRepository,
+            classRepository,
+            userAuthorizationService,
+            fixedClock
+        );
+    }
+
+    @Test
+    void WAITING_상태면_정원_변화_없이_CANCELLED로_변경한다() {
+        EnrollmentEntity enrollment = waitingEnrollment();
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+
+        EnrollmentEntity cancelled = enrollmentCancelService.cancel(1L, user);
+
+        assertThat(cancelled.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(cancelled.getCancelledAt()).isNotNull();
+        verify(classRepository, never()).tryDecrementEnrolled(10L);
+    }
+
+    @Test
+    void PENDING_상태면_정원을_복구하고_CANCELLED로_변경한다() {
+        EnrollmentEntity enrollment = pendingEnrollment();
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        when(classRepository.tryDecrementEnrolled(10L)).thenReturn(1);
+
+        EnrollmentEntity cancelled = enrollmentCancelService.cancel(1L, user);
+
+        assertThat(cancelled.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(cancelled.getCancelledAt()).isNotNull();
+        verify(classRepository).tryDecrementEnrolled(10L);
+    }
+
+    @Test
+    void CONFIRMED_상태고_7일_이내면_취소할_수_있다() {
+        EnrollmentEntity enrollment = confirmedEnrollment(FIXED_NOW.minusDays(6));
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        when(classRepository.tryDecrementEnrolled(10L)).thenReturn(1);
+
+        EnrollmentEntity cancelled = enrollmentCancelService.cancel(1L, user);
+
+        assertThat(cancelled.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(cancelled.getCancelledAt()).isNotNull();
+        verify(classRepository).tryDecrementEnrolled(10L);
+    }
+
+    @Test
+    void CONFIRMED_상태고_정확히_7일째면_취소할_수_있다() {
+        EnrollmentEntity enrollment = confirmedEnrollment(FIXED_NOW.minusDays(7));
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        when(classRepository.tryDecrementEnrolled(10L)).thenReturn(1);
+
+        EnrollmentEntity cancelled = enrollmentCancelService.cancel(1L, user);
+
+        assertThat(cancelled.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(cancelled.getCancelledAt()).isEqualTo(FIXED_NOW);
+        verify(classRepository).tryDecrementEnrolled(10L);
+    }
+
+    @Test
+    void CONFIRMED_상태고_7일이_지나면_CANCEL_PERIOD_EXPIRED를_반환한다() {
+        EnrollmentEntity enrollment = confirmedEnrollment(FIXED_NOW.minusDays(8));
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+
+        assertThatThrownBy(() -> enrollmentCancelService.cancel(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CANCEL_PERIOD_EXPIRED);
+
+        verify(classRepository, never()).tryDecrementEnrolled(10L);
+    }
+
+    @Test
+    void 이미_CANCELLED_상태면_INVALID_STATE_TRANSITION을_반환한다() {
+        EnrollmentEntity enrollment = cancelledEnrollment();
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+
+        assertThatThrownBy(() -> enrollmentCancelService.cancel(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.INVALID_STATE_TRANSITION);
+
+        verify(classRepository, never()).tryDecrementEnrolled(10L);
+    }
+
+    @Test
+    void 수강_신청이_없으면_ENROLLMENT_NOT_FOUND를_반환한다() {
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> enrollmentCancelService.cancel(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.ENROLLMENT_NOT_FOUND);
+    }
+
+    @Test
+    void 다른_사용자의_수강_신청이면_FORBIDDEN을_반환한다() {
+        EnrollmentEntity enrollment = pendingEnrollment();
+        CurrentUserInfo user = studentUser(21L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        doThrow(new ApiException(ErrorCode.FORBIDDEN))
+            .when(userAuthorizationService)
+            .requireOwner(user, 20L);
+
+        assertThatThrownBy(() -> enrollmentCancelService.cancel(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.FORBIDDEN);
+    }
+
+    @Test
+    void 동시성_충돌이면_CONFLICT_RETRY를_반환한다() {
+        EnrollmentEntity enrollment = pendingEnrollment();
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        doThrow(new ObjectOptimisticLockingFailureException(EnrollmentEntity.class, 1L))
+            .when(enrollmentRepository)
+            .saveAndFlush(enrollment);
+
+        assertThatThrownBy(() -> enrollmentCancelService.cancel(1L, user))
+            .isInstanceOf(ApiException.class)
+            .extracting("errorCode")
+            .isEqualTo(ErrorCode.CONFLICT_RETRY);
+
+        verify(classRepository, never()).tryDecrementEnrolled(10L);
+    }
+
+    private CurrentUserInfo studentUser(Long userId) {
+        return new CurrentUserInfo(userId, UserRole.STUDENT);
+    }
+
+    private EnrollmentEntity waitingEnrollment() {
+        EnrollmentEntity enrollment = EnrollmentEntity.createWaiting(10L, 20L);
+        ReflectionTestUtils.setField(enrollment, "id", 1L);
+        return enrollment;
+    }
+
+    private EnrollmentEntity pendingEnrollment() {
+        EnrollmentEntity enrollment = EnrollmentEntity.createPending(10L, 20L);
+        ReflectionTestUtils.setField(enrollment, "id", 1L);
+        return enrollment;
+    }
+
+    private EnrollmentEntity confirmedEnrollment(LocalDateTime confirmedAt) {
+        EnrollmentEntity enrollment = pendingEnrollment();
+        ReflectionTestUtils.setField(enrollment, "status", EnrollmentStatus.CONFIRMED);
+        ReflectionTestUtils.setField(enrollment, "confirmedAt", confirmedAt);
+        return enrollment;
+    }
+
+    private EnrollmentEntity cancelledEnrollment() {
+        EnrollmentEntity enrollment = pendingEnrollment();
+        ReflectionTestUtils.setField(enrollment, "status", EnrollmentStatus.CANCELLED);
+        ReflectionTestUtils.setField(enrollment, "cancelledAt", FIXED_NOW.minusDays(1));
+        return enrollment;
+    }
+}


### PR DESCRIPTION
## 연관 이슈
- Closes #19 

## 요약
  - 수강 취소 API 추가
  - 상태별 취소 규칙과 정원 복구 로직 반영
  - 취소 정책 및 DB 불변식 검증 테스트 추가

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
