### PR TITLE
대기열 승급 기능 구현

### DIFF
--- a/src/main/java/com/example/be_a/enrollment/application/EnrollmentCancelService.java
+++ b/src/main/java/com/example/be_a/enrollment/application/EnrollmentCancelService.java
@@ -46,7 +46,7 @@ public class EnrollmentCancelService {
             return enrollment;
         }
 
-        restoreCapacity(enrollment.getClassId());
+        restoreCapacityAndPromote(enrollment.getClassId());
         return enrollment;
     }
 
@@ -69,6 +69,21 @@ public class EnrollmentCancelService {
     private void restoreCapacity(Long classId) {
         if (classRepository.tryDecrementEnrolled(classId) == 0) {
             throw new IllegalStateException("수강 인원 복구에 실패했습니다. classId=" + classId);
+        }
+    }
+
+    private void restoreCapacityAndPromote(Long classId) {
+        restoreCapacity(classId);
+        promoteOldestWaiting(classId);
+    }
+
+    private void promoteOldestWaiting(Long classId) {
+        if (enrollmentRepository.tryPromoteOldestWaiting(classId) == 0) {
+            return;
+        }
+
+        if (classRepository.tryIncrementEnrolled(classId) == 0) {
+            throw new IllegalStateException("승급 좌석 재할당에 실패했습니다. classId=" + classId);
         }
     }
 }

--- a/src/main/java/com/example/be_a/enrollment/domain/EnrollmentRepository.java
+++ b/src/main/java/com/example/be_a/enrollment/domain/EnrollmentRepository.java
@@ -1,8 +1,32 @@
 package com.example.be_a.enrollment.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface EnrollmentRepository extends JpaRepository<EnrollmentEntity, Long> {
 
     boolean existsByClassIdAndUserId(Long classId, Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+        UPDATE enrollments e
+        JOIN (
+            SELECT waiting.id
+            FROM (
+                SELECT e2.id
+                FROM enrollments e2
+                JOIN classes c ON e2.class_id = c.id
+                WHERE e2.class_id = :classId
+                  AND c.status = 'OPEN'
+                  AND e2.status = 'WAITING'
+                ORDER BY e2.requested_at ASC, e2.id ASC
+                LIMIT 1
+            ) waiting
+        ) target ON e.id = target.id
+        SET e.status = 'PENDING',
+            e.version = e.version + 1
+        """, nativeQuery = true)
+    int tryPromoteOldestWaiting(@Param("classId") Long classId);
 }

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentCancelIntegrationTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentCancelIntegrationTest.java
@@ -55,6 +55,7 @@ class EnrollmentCancelIntegrationTest extends MySqlTestContainerSupport {
         ensureUser(10L, "creator10@example.com", "Creator Ten", "CREATOR");
         ensureUser(20L, "student20@example.com", "Student Twenty", "STUDENT");
         ensureUser(21L, "student21@example.com", "Student Twenty One", "STUDENT");
+        ensureUser(22L, "student22@example.com", "Student Twenty Two", "STUDENT");
         enrollmentRepository.deleteAllInBatch();
         classRepository.deleteAllInBatch();
     }
@@ -97,6 +98,98 @@ class EnrollmentCancelIntegrationTest extends MySqlTestContainerSupport {
 
         assertThat(enrollment.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
         assertThat(savedClass.getEnrolledCount()).isZero();
+    }
+
+    @Test
+    void PENDING_취소로_좌석이_복구되면_WAITING_신청을_PENDING으로_승급한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long pendingEnrollmentId = insertEnrollment(classEntity.getId(), 20L, EnrollmentStatus.PENDING, null, null);
+        Long waitingEnrollmentId = insertEnrollment(classEntity.getId(), 21L, EnrollmentStatus.WAITING, null, null);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", pendingEnrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(pendingEnrollmentId))
+            .andExpect(jsonPath("$.status").value("CANCELLED"));
+
+        EnrollmentEntity cancelled = enrollmentRepository.findById(pendingEnrollmentId).orElseThrow();
+        EnrollmentEntity promoted = enrollmentRepository.findById(waitingEnrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(cancelled.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(promoted.getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+    }
+
+    @Test
+    void CONFIRMED_취소로_좌석이_복구되면_WAITING_신청을_PENDING으로_승급한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long confirmedEnrollmentId = insertEnrollment(
+            classEntity.getId(),
+            20L,
+            EnrollmentStatus.CONFIRMED,
+            FIXED_NOW.minusDays(3),
+            null
+        );
+        Long waitingEnrollmentId = insertEnrollment(classEntity.getId(), 21L, EnrollmentStatus.WAITING, null, null);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", confirmedEnrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(confirmedEnrollmentId))
+            .andExpect(jsonPath("$.status").value("CANCELLED"));
+
+        EnrollmentEntity cancelled = enrollmentRepository.findById(confirmedEnrollmentId).orElseThrow();
+        EnrollmentEntity promoted = enrollmentRepository.findById(waitingEnrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(cancelled.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        assertThat(promoted.getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+    }
+
+    @Test
+    void 여러_WAITING이_있으면_가장_오래된_신청을_먼저_승급한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long pendingEnrollmentId = insertEnrollmentAt(
+            classEntity.getId(),
+            20L,
+            EnrollmentStatus.PENDING,
+            FIXED_NOW.minusDays(2),
+            null,
+            null
+        );
+        Long oldWaitingId = insertEnrollmentAt(
+            classEntity.getId(),
+            21L,
+            EnrollmentStatus.WAITING,
+            FIXED_NOW.minusDays(1).minusMinutes(1),
+            null,
+            null
+        );
+        Long newWaitingId = insertEnrollmentAt(
+            classEntity.getId(),
+            22L,
+            EnrollmentStatus.WAITING,
+            FIXED_NOW.minusDays(1),
+            null,
+            null
+        );
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", pendingEnrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk());
+
+        EnrollmentEntity oldWaiting = enrollmentRepository.findById(oldWaitingId).orElseThrow();
+        EnrollmentEntity newWaiting = enrollmentRepository.findById(newWaitingId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(oldWaiting.getStatus()).isEqualTo(EnrollmentStatus.PENDING);
+        assertThat(newWaiting.getStatus()).isEqualTo(EnrollmentStatus.WAITING);
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
     }
 
     @Test
@@ -220,6 +313,32 @@ class EnrollmentCancelIntegrationTest extends MySqlTestContainerSupport {
     }
 
     @Test
+    void CLOSED_강의는_수강_취소_후_WAITING을_승급하지_않는다() throws Exception {
+        ClassEntity classEntity = saveOpenClass();
+        updateEnrolledCount(classEntity.getId(), 1);
+        Long confirmedEnrollmentId = insertEnrollment(
+            classEntity.getId(),
+            20L,
+            EnrollmentStatus.CONFIRMED,
+            FIXED_NOW.minusDays(3),
+            null
+        );
+        Long waitingEnrollmentId = insertEnrollment(classEntity.getId(), 21L, EnrollmentStatus.WAITING, null, null);
+        updateStatus(classEntity.getId(), ClassStatus.CLOSED);
+
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", confirmedEnrollmentId)
+                .header("X-User-Id", "20"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("CANCELLED"));
+
+        EnrollmentEntity waiting = enrollmentRepository.findById(waitingEnrollmentId).orElseThrow();
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+
+        assertThat(waiting.getStatus()).isEqualTo(EnrollmentStatus.WAITING);
+        assertThat(savedClass.getEnrolledCount()).isZero();
+    }
+
+    @Test
     void 다른_사용자의_수강_신청은_취소할_수_없다() throws Exception {
         ClassEntity classEntity = saveOpenClass();
         updateEnrolledCount(classEntity.getId(), 1);
@@ -276,6 +395,17 @@ class EnrollmentCancelIntegrationTest extends MySqlTestContainerSupport {
         LocalDateTime confirmedAt,
         LocalDateTime cancelledAt
     ) {
+        return insertEnrollmentAt(classId, userId, status, FIXED_NOW.minusDays(3), confirmedAt, cancelledAt);
+    }
+
+    private Long insertEnrollmentAt(
+        Long classId,
+        Long userId,
+        EnrollmentStatus status,
+        LocalDateTime requestedAt,
+        LocalDateTime confirmedAt,
+        LocalDateTime cancelledAt
+    ) {
         jdbcTemplate.update("""
             INSERT INTO enrollments (class_id, user_id, status, requested_at, confirmed_at, cancelled_at)
             VALUES (?, ?, ?, ?, ?, ?)
@@ -283,7 +413,7 @@ class EnrollmentCancelIntegrationTest extends MySqlTestContainerSupport {
             classId,
             userId,
             status.name(),
-            FIXED_NOW.minusDays(3),
+            requestedAt,
             confirmedAt,
             cancelledAt
         );

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentCancelServiceTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentCancelServiceTest.java
@@ -78,12 +78,31 @@ class EnrollmentCancelServiceTest {
 
         when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
         when(classRepository.tryDecrementEnrolled(10L)).thenReturn(1);
+        givenOpenClassWithoutWaiting();
 
         EnrollmentEntity cancelled = enrollmentCancelService.cancel(1L, user);
 
         assertThat(cancelled.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
         assertThat(cancelled.getCancelledAt()).isNotNull();
         verify(classRepository).tryDecrementEnrolled(10L);
+        verify(classRepository, never()).tryIncrementEnrolled(10L);
+    }
+
+    @Test
+    void PENDING_취소_후_WAITING이_있으면_가장_오래된_대기자를_승급한다() {
+        EnrollmentEntity enrollment = pendingEnrollment();
+        CurrentUserInfo user = studentUser(20L);
+
+        when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
+        when(classRepository.tryDecrementEnrolled(10L)).thenReturn(1);
+        when(enrollmentRepository.tryPromoteOldestWaiting(10L)).thenReturn(1);
+        when(classRepository.tryIncrementEnrolled(10L)).thenReturn(1);
+
+        EnrollmentEntity cancelled = enrollmentCancelService.cancel(1L, user);
+
+        assertThat(cancelled.getStatus()).isEqualTo(EnrollmentStatus.CANCELLED);
+        verify(enrollmentRepository).tryPromoteOldestWaiting(10L);
+        verify(classRepository).tryIncrementEnrolled(10L);
     }
 
     @Test
@@ -93,6 +112,7 @@ class EnrollmentCancelServiceTest {
 
         when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
         when(classRepository.tryDecrementEnrolled(10L)).thenReturn(1);
+        givenOpenClassWithoutWaiting();
 
         EnrollmentEntity cancelled = enrollmentCancelService.cancel(1L, user);
 
@@ -108,6 +128,7 @@ class EnrollmentCancelServiceTest {
 
         when(enrollmentRepository.findById(1L)).thenReturn(Optional.of(enrollment));
         when(classRepository.tryDecrementEnrolled(10L)).thenReturn(1);
+        givenOpenClassWithoutWaiting();
 
         EnrollmentEntity cancelled = enrollmentCancelService.cancel(1L, user);
 
@@ -190,6 +211,10 @@ class EnrollmentCancelServiceTest {
             .isEqualTo(ErrorCode.CONFLICT_RETRY);
 
         verify(classRepository, never()).tryDecrementEnrolled(10L);
+    }
+
+    private void givenOpenClassWithoutWaiting() {
+        when(enrollmentRepository.tryPromoteOldestWaiting(10L)).thenReturn(0);
     }
 
     private CurrentUserInfo studentUser(Long userId) {


### PR DESCRIPTION
## 연관 이슈
- Closes #21 

## 요약
  - 수강 취소 시 대기열 자동 승급 기능 추가
  - WAITING 신청을 FIFO 기준으로 PENDING 상태로 전환
  - OPEN 강의에서만 승급되도록 동시성 안전장치 반영

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
