### PR TITLE
수강 신청 취소 후 재신청 불가 수정

### DIFF
--- a/src/main/java/com/example/be_a/enrollment/application/EnrollmentApplyService.java
+++ b/src/main/java/com/example/be_a/enrollment/application/EnrollmentApplyService.java
@@ -5,6 +5,7 @@ import com.example.be_a.class_.domain.ClassRepository;
 import com.example.be_a.class_.domain.ClassStatus;
 import com.example.be_a.enrollment.domain.EnrollmentEntity;
 import com.example.be_a.enrollment.domain.EnrollmentRepository;
+import com.example.be_a.enrollment.domain.EnrollmentStatus;
 import com.example.be_a.global.error.ApiException;
 import com.example.be_a.global.error.ErrorCode;
 import com.example.be_a.user.application.CurrentUserInfo;
@@ -17,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class EnrollmentApplyService {
 
-    private static final String ENROLLMENT_UNIQUE_CONSTRAINT = "uk_enrollments_class_user";
+    private static final String ENROLLMENT_UNIQUE_CONSTRAINT = "uk_enrollments_class_active_user";
 
     private final ClassRepository classRepository;
     private final EnrollmentRepository enrollmentRepository;
@@ -61,7 +62,11 @@ public class EnrollmentApplyService {
     }
 
     private void validateNotEnrolled(Long classId, Long userId) {
-        if (enrollmentRepository.existsByClassIdAndUserId(classId, userId)) {
+        if (enrollmentRepository.existsByClassIdAndUserIdAndStatusNot(
+            classId,
+            userId,
+            EnrollmentStatus.CANCELLED
+        )) {
             throw new ApiException(ErrorCode.ALREADY_ENROLLED);
         }
     }

--- a/src/main/java/com/example/be_a/enrollment/domain/EnrollmentRepository.java
+++ b/src/main/java/com/example/be_a/enrollment/domain/EnrollmentRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface EnrollmentRepository extends JpaRepository<EnrollmentEntity, Long> {
 
-    boolean existsByClassIdAndUserId(Long classId, Long userId);
+    boolean existsByClassIdAndUserIdAndStatusNot(Long classId, Long userId, EnrollmentStatus status);
 
     Page<EnrollmentEntity> findAllByUserId(Long userId, Pageable pageable);
 

--- a/src/main/java/com/example/be_a/enrollment/domain/EnrollmentRepository.java
+++ b/src/main/java/com/example/be_a/enrollment/domain/EnrollmentRepository.java
@@ -30,11 +30,31 @@ public interface EnrollmentRepository extends JpaRepository<EnrollmentEntity, Lo
             FROM EnrollmentEntity e
             JOIN UserEntity u ON e.userId = u.id
             WHERE e.classId = :classId
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM EnrollmentEntity newer
+                  WHERE newer.classId = e.classId
+                    AND newer.userId = e.userId
+                    AND (
+                        newer.requestedAt > e.requestedAt
+                        OR (newer.requestedAt = e.requestedAt AND newer.id > e.id)
+                    )
+              )
             """,
         countQuery = """
             SELECT COUNT(e)
             FROM EnrollmentEntity e
             WHERE e.classId = :classId
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM EnrollmentEntity newer
+                  WHERE newer.classId = e.classId
+                    AND newer.userId = e.userId
+                    AND (
+                        newer.requestedAt > e.requestedAt
+                        OR (newer.requestedAt = e.requestedAt AND newer.id > e.id)
+                    )
+              )
             """
     )
     Page<ClassEnrollmentSummaryView> findClassEnrollmentsByClassId(
@@ -57,12 +77,32 @@ public interface EnrollmentRepository extends JpaRepository<EnrollmentEntity, Lo
             JOIN UserEntity u ON e.userId = u.id
             WHERE e.classId = :classId
               AND e.status = :status
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM EnrollmentEntity newer
+                  WHERE newer.classId = e.classId
+                    AND newer.userId = e.userId
+                    AND (
+                        newer.requestedAt > e.requestedAt
+                        OR (newer.requestedAt = e.requestedAt AND newer.id > e.id)
+                    )
+              )
             """,
         countQuery = """
             SELECT COUNT(e)
             FROM EnrollmentEntity e
             WHERE e.classId = :classId
               AND e.status = :status
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM EnrollmentEntity newer
+                  WHERE newer.classId = e.classId
+                    AND newer.userId = e.userId
+                    AND (
+                        newer.requestedAt > e.requestedAt
+                        OR (newer.requestedAt = e.requestedAt AND newer.id > e.id)
+                    )
+              )
             """
     )
     Page<ClassEnrollmentSummaryView> findClassEnrollmentsByClassIdAndStatus(

--- a/src/main/resources/db/migration/V4__allow_reapply_after_cancelled_enrollment.sql
+++ b/src/main/resources/db/migration/V4__allow_reapply_after_cancelled_enrollment.sql
@@ -1,0 +1,12 @@
+ALTER TABLE enrollments
+    DROP INDEX uk_enrollments_class_user,
+    ADD COLUMN active_user_id BIGINT GENERATED ALWAYS AS (
+        CASE
+            WHEN status <> 'CANCELLED' THEN user_id
+            ELSE NULL
+        END
+    ) VIRTUAL,
+    ADD CONSTRAINT uk_enrollments_class_active_user UNIQUE (class_id, active_user_id);
+
+CREATE INDEX idx_enrollments_class_user_status
+    ON enrollments (class_id, user_id, status);

--- a/src/test/java/com/example/be_a/FlywayMigrationIntegrationTest.java
+++ b/src/test/java/com/example/be_a/FlywayMigrationIntegrationTest.java
@@ -49,7 +49,49 @@ class FlywayMigrationIntegrationTest extends MySqlTestContainerSupport {
                 WHERE table_schema = DATABASE()
                   AND table_name = 'enrollments'
                   AND index_name = 'idx_enrollments_user_status_id_desc'
-                """,
+            """,
+            Integer.class
+        );
+        Integer activeEnrollmentColumns = jdbcTemplate.queryForObject(
+            """
+                SELECT COUNT(*)
+                FROM information_schema.columns
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'enrollments'
+                  AND column_name = 'active_user_id'
+                  AND generation_expression IS NOT NULL
+            """,
+            Integer.class
+        );
+        Integer activeEnrollmentUniqueIndexes = jdbcTemplate.queryForObject(
+            """
+                SELECT COUNT(DISTINCT index_name)
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'enrollments'
+                  AND index_name = 'uk_enrollments_class_active_user'
+                  AND non_unique = 0
+            """,
+            Integer.class
+        );
+        Integer legacyEnrollmentUniqueIndexes = jdbcTemplate.queryForObject(
+            """
+                SELECT COUNT(DISTINCT index_name)
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'enrollments'
+                  AND index_name = 'uk_enrollments_class_user'
+            """,
+            Integer.class
+        );
+        Integer enrollmentClassUserStatusIndexes = jdbcTemplate.queryForObject(
+            """
+                SELECT COUNT(DISTINCT index_name)
+                FROM information_schema.statistics
+                WHERE table_schema = DATABASE()
+                  AND table_name = 'enrollments'
+                  AND index_name = 'idx_enrollments_class_user_status'
+            """,
             Integer.class
         );
 
@@ -57,5 +99,9 @@ class FlywayMigrationIntegrationTest extends MySqlTestContainerSupport {
         assertThat(userCount).isEqualTo(3);
         assertThat(enrollmentCheckConstraints).isEqualTo(2);
         assertThat(enrollmentMyListIndexes).isGreaterThan(0);
+        assertThat(activeEnrollmentColumns).isEqualTo(1);
+        assertThat(activeEnrollmentUniqueIndexes).isEqualTo(1);
+        assertThat(legacyEnrollmentUniqueIndexes).isZero();
+        assertThat(enrollmentClassUserStatusIndexes).isEqualTo(1);
     }
 }

--- a/src/test/java/com/example/be_a/class_/ClassEnrollmentReadIntegrationTest.java
+++ b/src/test/java/com/example/be_a/class_/ClassEnrollmentReadIntegrationTest.java
@@ -77,6 +77,39 @@ class ClassEnrollmentReadIntegrationTest extends MySqlTestContainerSupport {
     }
 
     @Test
+    void 같은_사용자가_취소_후_재신청하면_최신_수강_신청만_목록에_노출한다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, "재신청 목록 강의");
+        insertEnrollmentAt(classEntity.getId(), 30L, EnrollmentStatus.CANCELLED, FIXED_NOW.minusMinutes(2));
+        Long reappliedId = insertEnrollmentAt(
+            classEntity.getId(),
+            30L,
+            EnrollmentStatus.PENDING,
+            FIXED_NOW.minusMinutes(1)
+        );
+
+        mockMvc.perform(get("/api/classes/{classId}/enrollments", classEntity.getId())
+                .header("X-User-Id", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items.length()").value(1))
+            .andExpect(jsonPath("$.items[0].enrollmentId").value(reappliedId))
+            .andExpect(jsonPath("$.items[0].userId").value(30))
+            .andExpect(jsonPath("$.items[0].status").value("PENDING"));
+
+        mockMvc.perform(get("/api/classes/{classId}/enrollments", classEntity.getId())
+                .header("X-User-Id", "10")
+                .param("status", "CANCELLED"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items.length()").value(0));
+
+        mockMvc.perform(get("/api/classes/{classId}/enrollments", classEntity.getId())
+                .header("X-User-Id", "10")
+                .param("status", "PENDING"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items.length()").value(1))
+            .andExpect(jsonPath("$.items[0].enrollmentId").value(reappliedId));
+    }
+
+    @Test
     void 다른_크리에이터_강의는_FORBIDDEN을_반환한다() throws Exception {
         ClassEntity classEntity = saveOpenClass(20L, "다른 사람 강의");
 
@@ -208,7 +241,7 @@ class ClassEnrollmentReadIntegrationTest extends MySqlTestContainerSupport {
         );
 
         return jdbcTemplate.queryForObject(
-            "SELECT id FROM enrollments WHERE class_id = ? AND user_id = ?",
+            "SELECT id FROM enrollments WHERE class_id = ? AND user_id = ? ORDER BY id DESC LIMIT 1",
             Long.class,
             classId,
             userId

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentApplyConcurrencyIntegrationTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentApplyConcurrencyIntegrationTest.java
@@ -18,6 +18,7 @@ import com.example.be_a.support.MySqlTestContainerSupport;
 import com.example.be_a.user.application.CurrentUserInfo;
 import com.example.be_a.user.domain.UserRole;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Callable;
@@ -137,7 +138,11 @@ class EnrollmentApplyConcurrencyIntegrationTest extends MySqlTestContainerSuppor
                 return false;
             }
             return invocation.callRealMethod();
-        }).when(enrollmentRepositorySpy).existsByClassIdAndUserId(eq(classEntity.getId()), eq(20L));
+        }).when(enrollmentRepositorySpy).existsByClassIdAndUserIdAndStatusNot(
+            eq(classEntity.getId()),
+            eq(20L),
+            eq(EnrollmentStatus.CANCELLED)
+        );
 
         Callable<Void> applyTask = () -> {
             try {
@@ -176,6 +181,70 @@ class EnrollmentApplyConcurrencyIntegrationTest extends MySqlTestContainerSuppor
         assertThat(enrollments.get(0).getStatus()).isEqualTo(EnrollmentStatus.PENDING);
     }
 
+    @Test
+    void CANCELLED_이력이_있는_사용자가_동시에_두_번_재신청하면_한_건만_PENDING으로_저장된다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 10, "취소 이력 재신청 경합 강의");
+        insertCancelledEnrollment(classEntity.getId(), 20L);
+        Queue<String> results = new ConcurrentLinkedQueue<>();
+        CountDownLatch existsReadyLatch = new CountDownLatch(2);
+        CountDownLatch existsReleaseLatch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            Long classId = invocation.getArgument(0);
+            Long userId = invocation.getArgument(1);
+            if (classEntity.getId().equals(classId) && Long.valueOf(20L).equals(userId)) {
+                existsReadyLatch.countDown();
+                assertThat(existsReleaseLatch.await(5, TimeUnit.SECONDS)).isTrue();
+                return false;
+            }
+            return invocation.callRealMethod();
+        }).when(enrollmentRepositorySpy).existsByClassIdAndUserIdAndStatusNot(
+            eq(classEntity.getId()),
+            eq(20L),
+            eq(EnrollmentStatus.CANCELLED)
+        );
+
+        Callable<Void> applyTask = () -> {
+            try {
+                enrollmentApplyService.apply(
+                    new CurrentUserInfo(20L, UserRole.STUDENT),
+                    new ApplyEnrollmentCommand(classEntity.getId(), false)
+                );
+                results.add("PENDING");
+            } catch (ApiException exception) {
+                results.add(exception.getErrorCode().name());
+            } catch (Exception exception) {
+                results.add("ERROR:" + exception.getClass().getSimpleName());
+            }
+            return null;
+        };
+
+        var first = executorService.submit(applyTask);
+        var second = executorService.submit(applyTask);
+
+        assertThat(existsReadyLatch.await(5, TimeUnit.SECONDS)).isTrue();
+        existsReleaseLatch.countDown();
+
+        first.get(10, TimeUnit.SECONDS);
+        second.get(10, TimeUnit.SECONDS);
+
+        long successCount = results.stream().filter("PENDING"::equals).count();
+        long duplicateCount = results.stream().filter("ALREADY_ENROLLED"::equals).count();
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        List<EnrollmentEntity> enrollments = enrollmentRepository.findAll();
+
+        assertThat(results).hasSize(2);
+        assertThat(successCount).isEqualTo(1);
+        assertThat(duplicateCount).isEqualTo(1);
+        assertThat(results.stream().filter(result -> result.startsWith("ERROR:"))).isEmpty();
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollments).hasSize(2);
+        assertThat(enrollments)
+            .extracting(EnrollmentEntity::getStatus)
+            .containsExactlyInAnyOrder(EnrollmentStatus.CANCELLED, EnrollmentStatus.PENDING);
+    }
+
     private void ensureUser(Long id, String email, String name, String role) {
         jdbcTemplate.update("""
             INSERT INTO users (id, email, name, role)
@@ -196,5 +265,19 @@ class EnrollmentApplyConcurrencyIntegrationTest extends MySqlTestContainerSuppor
         ));
         jdbcTemplate.update("UPDATE classes SET status = ? WHERE id = ?", ClassStatus.OPEN.name(), classEntity.getId());
         return classRepository.findById(classEntity.getId()).orElseThrow();
+    }
+
+    private void insertCancelledEnrollment(Long classId, Long userId) {
+        LocalDateTime cancelledAt = LocalDateTime.of(2026, 4, 23, 10, 0);
+        jdbcTemplate.update("""
+            INSERT INTO enrollments (class_id, user_id, status, requested_at, cancelled_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            classId,
+            userId,
+            EnrollmentStatus.CANCELLED.name(),
+            cancelledAt.minusDays(1),
+            cancelledAt
+        );
     }
 }

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentApplyIntegrationTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentApplyIntegrationTest.java
@@ -95,6 +95,92 @@ class EnrollmentApplyIntegrationTest extends MySqlTestContainerSupport {
     }
 
     @Test
+    void CANCELLED_이력이_있는_사용자는_같은_강의를_다시_신청할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 1, "재신청 가능 강의");
+        apply(classEntity.getId(), 20L, false);
+        cancel(latestEnrollmentId(classEntity.getId(), 20L), 20L);
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), false)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", matchesPattern("/api/enrollments/\\d+")))
+            .andExpect(jsonPath("$.classId").value(classEntity.getId()))
+            .andExpect(jsonPath("$.userId").value(20))
+            .andExpect(jsonPath("$.status").value("PENDING"));
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        List<EnrollmentEntity> enrollments = enrollmentRepository.findAll();
+
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollments).hasSize(2);
+        assertThat(enrollments)
+            .extracting(EnrollmentEntity::getStatus)
+            .containsExactlyInAnyOrder(EnrollmentStatus.CANCELLED, EnrollmentStatus.PENDING);
+    }
+
+    @Test
+    void WAITING_취소_이력이_있는_사용자는_같은_강의를_다시_신청할_수_있다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 1, "대기 취소 후 재신청 강의");
+        apply(classEntity.getId(), 20L, false);
+        apply(classEntity.getId(), 21L, true);
+        cancel(latestEnrollmentId(classEntity.getId(), 21L), 21L);
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "21")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), true)))
+            .andExpect(status().isCreated())
+            .andExpect(header().string("Location", matchesPattern("/api/enrollments/\\d+")))
+            .andExpect(jsonPath("$.classId").value(classEntity.getId()))
+            .andExpect(jsonPath("$.userId").value(21))
+            .andExpect(jsonPath("$.status").value("WAITING"));
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        List<EnrollmentEntity> enrollments = enrollmentRepository.findAll();
+
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollments).hasSize(3);
+        assertThat(enrollments)
+            .extracting(EnrollmentEntity::getStatus)
+            .containsExactlyInAnyOrder(
+                EnrollmentStatus.PENDING,
+                EnrollmentStatus.CANCELLED,
+                EnrollmentStatus.WAITING
+            );
+    }
+
+    @Test
+    void 같은_사용자가_여러_번_취소_재신청해도_활성_신청은_하나만_유지된다() throws Exception {
+        ClassEntity classEntity = saveOpenClass(10L, 1, "반복 재신청 강의");
+        apply(classEntity.getId(), 20L, false);
+        cancel(latestEnrollmentId(classEntity.getId(), 20L), 20L);
+        apply(classEntity.getId(), 20L, false);
+        cancel(latestEnrollmentId(classEntity.getId(), 20L), 20L);
+
+        mockMvc.perform(post("/api/enrollments")
+                .header("X-User-Id", "20")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody(classEntity.getId(), false)))
+            .andExpect(status().isCreated())
+            .andExpect(jsonPath("$.status").value("PENDING"));
+
+        ClassEntity savedClass = classRepository.findById(classEntity.getId()).orElseThrow();
+        List<EnrollmentEntity> enrollments = enrollmentRepository.findAll();
+
+        assertThat(savedClass.getEnrolledCount()).isEqualTo(1);
+        assertThat(enrollments).hasSize(3);
+        assertThat(enrollments)
+            .extracting(EnrollmentEntity::getStatus)
+            .containsExactlyInAnyOrder(
+                EnrollmentStatus.CANCELLED,
+                EnrollmentStatus.CANCELLED,
+                EnrollmentStatus.PENDING
+            );
+    }
+
+    @Test
     void DRAFT_강의는_CLASS_NOT_OPEN을_반환한다() throws Exception {
         ClassEntity classEntity = saveDraftClass(10L, 1, "초안 강의");
 
@@ -183,6 +269,22 @@ class EnrollmentApplyIntegrationTest extends MySqlTestContainerSupport {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody(classId, waitlist)))
             .andExpect(status().isCreated());
+    }
+
+    private void cancel(Long enrollmentId, Long userId) throws Exception {
+        mockMvc.perform(post("/api/enrollments/{enrollmentId}/cancel", enrollmentId)
+                .header("X-User-Id", String.valueOf(userId)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value("CANCELLED"));
+    }
+
+    private Long latestEnrollmentId(Long classId, Long userId) {
+        return jdbcTemplate.queryForObject(
+            "SELECT id FROM enrollments WHERE class_id = ? AND user_id = ? ORDER BY id DESC LIMIT 1",
+            Long.class,
+            classId,
+            userId
+        );
     }
 
     private String requestBody(Long classId, boolean waitlist) {

--- a/src/test/java/com/example/be_a/enrollment/EnrollmentApplyServiceTest.java
+++ b/src/test/java/com/example/be_a/enrollment/EnrollmentApplyServiceTest.java
@@ -46,12 +46,12 @@ class EnrollmentApplyServiceTest {
     void 저장_중_UNIQUE_예외가_나면_ALREADY_ENROLLED로_변환한다() {
         CurrentUserInfo user = studentUser(20L);
 
-        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(enrollmentRepository.existsByClassIdAndUserIdAndStatusNot(1L, 20L, EnrollmentStatus.CANCELLED)).thenReturn(false);
         when(classRepository.tryIncrementEnrolled(1L)).thenReturn(1);
         when(enrollmentRepository.saveAndFlush(any()))
             .thenThrow(new DataIntegrityViolationException(
                 "duplicate key",
-                new ConstraintViolationException("duplicate key", null, "UK_ENROLLMENTS_CLASS_USER")
+                new ConstraintViolationException("duplicate key", null, "UK_ENROLLMENTS_CLASS_ACTIVE_USER")
             ));
 
         assertThatThrownBy(() -> enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, false)))
@@ -64,7 +64,7 @@ class EnrollmentApplyServiceTest {
     void UNIQUE가_아닌_무결성_예외는_그대로_전파한다() {
         CurrentUserInfo user = studentUser(20L);
 
-        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(enrollmentRepository.existsByClassIdAndUserIdAndStatusNot(1L, 20L, EnrollmentStatus.CANCELLED)).thenReturn(false);
         when(classRepository.tryIncrementEnrolled(1L)).thenReturn(1);
         when(enrollmentRepository.saveAndFlush(any()))
             .thenThrow(new DataIntegrityViolationException(
@@ -80,7 +80,7 @@ class EnrollmentApplyServiceTest {
     void 중복_신청이면_정원_증가를_시도하지_않고_ALREADY_ENROLLED를_반환한다() {
         CurrentUserInfo user = studentUser(20L);
 
-        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(true);
+        when(enrollmentRepository.existsByClassIdAndUserIdAndStatusNot(1L, 20L, EnrollmentStatus.CANCELLED)).thenReturn(true);
 
         assertThatThrownBy(() -> enrollmentApplyService.apply(user, new ApplyEnrollmentCommand(1L, false)))
             .isInstanceOf(ApiException.class)
@@ -95,7 +95,7 @@ class EnrollmentApplyServiceTest {
     void 강의가_없으면_CLASS_NOT_FOUND를_반환한다() {
         CurrentUserInfo user = studentUser(20L);
 
-        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(enrollmentRepository.existsByClassIdAndUserIdAndStatusNot(1L, 20L, EnrollmentStatus.CANCELLED)).thenReturn(false);
         when(classRepository.tryIncrementEnrolled(1L)).thenReturn(0);
         when(classRepository.findById(1L)).thenReturn(Optional.empty());
 
@@ -111,7 +111,7 @@ class EnrollmentApplyServiceTest {
     void 정원_증가_실패_후_강의가_CLOSED면_CLASS_NOT_OPEN을_반환한다() {
         CurrentUserInfo user = studentUser(20L);
 
-        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(enrollmentRepository.existsByClassIdAndUserIdAndStatusNot(1L, 20L, EnrollmentStatus.CANCELLED)).thenReturn(false);
         when(classRepository.tryIncrementEnrolled(1L)).thenReturn(0);
         when(classRepository.findById(1L)).thenReturn(Optional.of(classWithStatus(10L, "마감 강의", ClassStatus.CLOSED)));
 
@@ -127,7 +127,7 @@ class EnrollmentApplyServiceTest {
     void 정원_증가_실패_후_WAITLIST를_사용하지_않으면_CLASS_FULL을_반환한다() {
         CurrentUserInfo user = studentUser(20L);
 
-        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(enrollmentRepository.existsByClassIdAndUserIdAndStatusNot(1L, 20L, EnrollmentStatus.CANCELLED)).thenReturn(false);
         when(classRepository.tryIncrementEnrolled(1L)).thenReturn(0);
         when(classRepository.findById(1L)).thenReturn(Optional.of(classWithStatus(10L, "만석 강의", ClassStatus.OPEN)));
 
@@ -144,7 +144,7 @@ class EnrollmentApplyServiceTest {
         CurrentUserInfo user = studentUser(20L);
         ArgumentCaptor<EnrollmentEntity> enrollmentCaptor = ArgumentCaptor.forClass(EnrollmentEntity.class);
 
-        when(enrollmentRepository.existsByClassIdAndUserId(1L, 20L)).thenReturn(false);
+        when(enrollmentRepository.existsByClassIdAndUserIdAndStatusNot(1L, 20L, EnrollmentStatus.CANCELLED)).thenReturn(false);
         when(classRepository.tryIncrementEnrolled(1L)).thenReturn(0);
         when(classRepository.findById(1L)).thenReturn(Optional.of(classWithStatus(10L, "대기열 강의", ClassStatus.OPEN)));
         when(enrollmentRepository.saveAndFlush(any()))


### PR DESCRIPTION
## 연관 이슈
- Closes #28 

## 요약
  - `CANCELLED` 된 수강 신청 이력이 있는 사용자가 같은 강의를 다시 신청할 수 없던 문제 수정
  - 기존 `(class_id, user_id)` 전체 UNIQUE 제약을 활성 신청 기준 UNIQUE 제약으로 변경
  - 크리에이터 수강생 목록은 이력 감사 화면이 아니라 사용자별 최신 수강 신청 상태 목록으로 취급하도록 정리

## 변경 내용
- 

## 검증
- [x] Build
- [x] Test
- [ ] Manual (필요 시)

## 참고
- 
